### PR TITLE
Disable remote playback to hide chromecast button

### DIFF
--- a/src/components/screens/IndexScreen/IndexScreen.js
+++ b/src/components/screens/IndexScreen/IndexScreen.js
@@ -71,6 +71,7 @@ export function PureIndexScreen({ data: { gitHubRepoData, allMediumPost }, ...pr
               src="videos/storybook-workflow-build-optimized-lg.mp4"
               alt="Storybook build workflow video"
               shouldChangeSize
+              disableremoteplayback="true"
             />
           </Placeholder>
         }
@@ -132,6 +133,7 @@ export function PureIndexScreen({ data: { gitHubRepoData, allMediumPost }, ...pr
                 src="videos/storybook-workflow-test-optimized-lg.mp4"
                 alt="Storybook testing workflow video"
                 shouldChangeSize
+                disableremoteplayback="true"
               />
             </Placeholder>
           }
@@ -189,6 +191,7 @@ export function PureIndexScreen({ data: { gitHubRepoData, allMediumPost }, ...pr
               src="videos/storybook-workflow-share-optimized-lg.mp4"
               alt="Storybook component reuse workflow video"
               shouldChangeSize
+              disableremoteplayback="true"
             />
           </Placeholder>
         }


### PR DESCRIPTION
**Issue** 
Chromecast button shows up on inline videos.
![image](https://user-images.githubusercontent.com/263385/60608456-85aa7080-9d8d-11e9-915c-ce063b2eab60.png)

**Expected behavior**
Chromecast button should not show up on videos