### PR TITLE
Add storybook-addon-responsive-views to list of community addons

### DIFF
--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -249,6 +249,11 @@ export function PureAddonScreen({ data: { allMediumPost }, ...props }) {
           desc="Toggle the locale and directly see the result in the preview."
           addonUrl="https://github.com/truffls/storybook-addon-intl"
         />
+        <AddonItem
+          title="Responsive Views"
+          desc="View your stories in a range of responsive viewports"
+          addonUrl="https://github.com/vizeat/storybook-addon-responsive-views"
+        />
 
         <Subheader>Code</Subheader>
         <AddonItem


### PR DESCRIPTION
This Storybook addon lets you preview your stories at a variety of breakpoints, so that you can be sure that your components will look great no matter what screen size