### PR TITLE
Remove Medium integration so we can deploy again

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,12 +42,6 @@ module.exports = {
         writeKey: 'AvvBObOmHaEMqfub8JJUXq5umjsuaqS8',
       },
     },
-    {
-      resolve: `gatsby-source-medium`,
-      options: {
-        username: `storybookjs`,
-      },
-    },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "gatsby-plugin-web-font-loader": "^1.0.4",
     "gatsby-source-filesystem": "^2.0.4",
     "gatsby-source-github-repo": "^1.0.4",
-    "gatsby-source-medium": "^2.0.3",
     "gatsby-transformer-sharp": "^2.1.4",
     "global": "^4.3.2",
     "lodash": "^4.17.11",

--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -24,27 +24,9 @@ const Title = styled(Subheading)`
   color: ${color.mediumdark};
 `;
 
-const SubLink = styled(Link)`
-  text-transform: none;
-  letter-spacing: 0;
-  font-weight: ${typography.weight.regular};
-  margin-left: 20px;
-`;
-
 const ResourceTitle = styled.div`
   font-weight: ${typography.weight.extrabold};
   margin-bottom: 0.25rem;
-`;
-
-const ResourceTitleLink = styled(Link)`
-  font-weight: ${typography.weight.extrabold};
-  margin-bottom: 0.25rem;
-
-  svg {
-    height: 0.7rem;
-    width: 0.7rem;
-    vertical-align: initial;
-  }
 `;
 
 const ResourceDesc = styled.div`
@@ -329,12 +311,11 @@ LinkWrapper.propTypes = {
   isGatsby: PropTypes.bool.isRequired,
 };
 
-export default function Footer({ mediumPosts, ...props }) {
+export default function Footer({ ...props }) {
   const { urls = {} } = useSiteMetadata();
   const {
     blog,
     twitter,
-    medium,
     chat,
     youtube,
     navLinks = {},
@@ -348,12 +329,11 @@ export default function Footer({ mediumPosts, ...props }) {
     <FooterWrapper {...props}>
       <Upper>
         <UpperColumn>
-          <Title>Learn</Title>
           <Resources>
             <Resource>
               <img src={RepoSVG} alt="Docs" />
               <Meta>
-                <ResourceTitle>Get started with Storybook</ResourceTitle>
+                <ResourceTitle>Storybook documentation</ResourceTitle>
                 <ResourceDesc>
                   Add Storybook to your project in less than a minute to build components faster and
                   easier.
@@ -374,6 +354,10 @@ export default function Footer({ mediumPosts, ...props }) {
                 </ResourceActions>
               </Meta>
             </Resource>
+          </Resources>
+        </UpperColumn>
+        <UpperColumn>
+          <Resources>
             <Resource>
               <img src={DirectionSVG} alt="Tutorial" />
               <Meta>
@@ -389,26 +373,6 @@ export default function Footer({ mediumPosts, ...props }) {
                 </ResourceActions>
               </Meta>
             </Resource>
-          </Resources>
-        </UpperColumn>
-        <UpperColumn>
-          <Title>
-            News
-            <SubLink tertiary withArrow href={blog}>
-              Read more
-            </SubLink>
-          </Title>
-          <Resources>
-            {mediumPosts.edges.map(({ node: { id, title, virtuals, uniqueSlug } }) => (
-              <Resource key={id}>
-                <Meta>
-                  <ResourceTitleLink tertiary withArrow href={`${medium}/${uniqueSlug}`}>
-                    {title}
-                  </ResourceTitleLink>
-                  <ResourceDesc>{virtuals.subtitle}</ResourceDesc>
-                </Meta>
-              </Resource>
-            ))}
           </Resources>
         </UpperColumn>
       </Upper>
@@ -493,19 +457,4 @@ export default function Footer({ mediumPosts, ...props }) {
   );
 }
 
-Footer.propTypes = {
-  mediumPosts: PropTypes.shape({
-    edges: PropTypes.arrayOf(
-      PropTypes.shape({
-        node: PropTypes.shape({
-          id: PropTypes.string,
-          title: PropTypes.string,
-          virtuals: PropTypes.shape({
-            subtitle: PropTypes.string,
-          }),
-          uniqueSlug: PropTypes.string,
-        }),
-      })
-    ),
-  }).isRequired,
-};
+Footer.propTypes = {};

--- a/src/components/layout/Footer.stories.js
+++ b/src/components/layout/Footer.stories.js
@@ -3,40 +3,4 @@ import { storiesOf } from '@storybook/react';
 
 import Footer from './Footer';
 
-// eslint-disable-next-line import/prefer-default-export
-export const allMediumPost = {
-  edges: [
-    {
-      node: {
-        id: 'bb9ae747-0318-54c1-8a5c-72b07798207a',
-        title: 'Storybook Governance',
-        virtuals: {
-          subtitle: 'Supporting open open source',
-        },
-        uniqueSlug: 'storybook-governance-4d9e5bb39019',
-      },
-    },
-    {
-      node: {
-        id: 'ff58e306-41d6-5fb1-9d51-92a166ac3c15',
-        title: 'Storybook 4.1: Need for Speed',
-        virtuals: {
-          subtitle: 'Up to 300% faster, compatibility, convenience',
-        },
-        uniqueSlug: 'storybook-4-1-need-for-speed-b05fd5f1e83d',
-      },
-    },
-    {
-      node: {
-        id: 'e8001e9d-7427-548e-8fc6-8fb3a4c4b225',
-        title: 'Storybook 4 Migration Guide',
-        virtuals: {
-          subtitle: 'Three steps to next-generation UI development',
-        },
-        uniqueSlug: 'migrating-to-storybook-4-c65b19a03d2c',
-      },
-    },
-  ],
-};
-
-storiesOf('Frontpage|layout/Footer', module).add('default', () => <Footer mediumPosts={allMediumPost} />);
+storiesOf('Frontpage|layout/Footer', module).add('default', () => <Footer />);

--- a/src/components/layout/PageLayout.js
+++ b/src/components/layout/PageLayout.js
@@ -11,7 +11,7 @@ import Footer from './Footer';
 
 const Layout = styled.div``;
 
-export default function PageLayout({ allMediumPost, children, ...props }) {
+export default function PageLayout({ children, ...props }) {
   const { urls = {}, title, description, ogImage, googleSiteVerification } = useSiteMetadata();
   return (
     <Layout {...props}>
@@ -43,16 +43,13 @@ export default function PageLayout({ allMediumPost, children, ...props }) {
       </Helmet>
       <Header />
       {children}
-      <Footer mediumPosts={allMediumPost} />
+      <Footer />
     </Layout>
   );
 }
 
 PageLayout.propTypes = {
   children: PropTypes.node.isRequired,
-  allMediumPost: PropTypes.any, // eslint-disable-line react/forbid-prop-types
 };
 
-PageLayout.defaultProps = {
-  allMediumPost: undefined,
-};
+PageLayout.defaultProps = {};

--- a/src/components/layout/PageLayout.stories.js
+++ b/src/components/layout/PageLayout.stories.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import PageLayout from './PageLayout';
-import { allMediumPost } from './Footer.stories';
 
-storiesOf('Frontpage|layout/PageLayout', module)
-  .add('not subscribed', () => <PageLayout allMediumPost={allMediumPost}>children</PageLayout>)
-  .add('subscribed', () => <PageLayout allMediumPost={allMediumPost}>children</PageLayout>);
+storiesOf('Frontpage|layout/PageLayout', module).add('default', () => (
+  <PageLayout>children</PageLayout>
+));

--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { StaticQuery, graphql } from 'gatsby';
 
 import { Button, Icon, Subheading, styles } from '@storybook/design-system';
 import useSiteMetadata from '../../lib/useSiteMetadata';
@@ -80,11 +79,11 @@ const MakeYourOwn = styled(AddonCustom)`
   margin-bottom: 5rem;
 `;
 
-export function PureAddonScreen({ data: { allMediumPost }, ...props }) {
+export function PureAddonScreen({ ...props }) {
   const { title, ogImage, urls = {} } = useSiteMetadata();
   const { home, officialAddons = {}, gitHub = {}, docs = {} } = urls;
   return (
-    <PageLayout allMediumPost={allMediumPost} {...props}>
+    <PageLayout {...props}>
       <SocialGraph
         title={`Addons | ${title}`}
         desc="Addons enable advanced functionality and unlock new workflows. Contributed by core maintainers and the amazing developer community."
@@ -363,26 +362,5 @@ PureAddonScreen.propTypes = {
 };
 
 export default function AddonScreen(props) {
-  return (
-    <StaticQuery
-      query={graphql`
-        query AddonsScreenQuery {
-          allMediumPost(sort: { fields: [createdAt], order: DESC }, limit: 3) {
-            edges {
-              node {
-                id
-                title
-                virtuals {
-                  subtitle
-                }
-                medium_id
-                uniqueSlug
-              }
-            }
-          }
-        }
-      `}
-      render={data => <PureAddonScreen data={data} {...props} />}
-    />
-  );
+  return <PureAddonScreen {...props} />;
 }

--- a/src/components/screens/AddonScreen/AddonScreen.stories.js
+++ b/src/components/screens/AddonScreen/AddonScreen.stories.js
@@ -3,11 +3,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { PureAddonScreen } from './AddonScreen';
-import { allMediumPost } from '../../layout/Footer.stories';
 
 storiesOf('Frontpage|screens/AddonScreen/AddonScreen', module).add(
   'default',
-  () => <PureAddonScreen data={{ allMediumPost }} />,
+  () => <PureAddonScreen />,
   {
     chromatic: { viewports: [320, 1200] },
   }

--- a/src/components/screens/CommunityScreen/CommunityScreen.js
+++ b/src/components/screens/CommunityScreen/CommunityScreen.js
@@ -154,7 +154,7 @@ const CommunityLayout = styled.div`
   }
 `;
 
-export function PureCommunityScreen({ data: { gitHubRepoData, allMediumPost }, ...props }) {
+export function PureCommunityScreen({ data: { gitHubRepoData }, ...props }) {
   const { title, ogImage, urls = {} } = useSiteMetadata();
   const {
     home,
@@ -169,7 +169,7 @@ export function PureCommunityScreen({ data: { gitHubRepoData, allMediumPost }, .
     openCollective,
   } = urls;
   return (
-    <PageLayout allMediumPost={allMediumPost} {...props}>
+    <PageLayout {...props}>
       <SocialGraph
         title={`Community | ${title}`}
         desc="Join thousands of frontend developers to learn new Storybook techniques, get help, and develop UIs faster."
@@ -392,19 +392,6 @@ export default function CommunityScreen(props) {
             author
             name
             url
-          }
-          allMediumPost(sort: { fields: [createdAt], order: DESC }, limit: 3) {
-            edges {
-              node {
-                id
-                title
-                virtuals {
-                  subtitle
-                }
-                medium_id
-                uniqueSlug
-              }
-            }
           }
         }
       `}

--- a/src/components/screens/CommunityScreen/CommunityScreen.stories.js
+++ b/src/components/screens/CommunityScreen/CommunityScreen.stories.js
@@ -4,11 +4,10 @@ import { storiesOf } from '@storybook/react';
 
 import { PureCommunityScreen } from './CommunityScreen';
 import { gitHubRepoData } from './CommunityHero.stories';
-import { allMediumPost } from '../../layout/Footer.stories';
 
 storiesOf('Frontpage|screens/CommunityScreen/CommunityScreen', module).add(
   'default',
-  () => <PureCommunityScreen data={{ gitHubRepoData, allMediumPost }} />,
+  () => <PureCommunityScreen data={{ gitHubRepoData }} />,
   {
     chromatic: { viewports: [320, 1200] },
   }

--- a/src/components/screens/IndexScreen/IndexScreen.js
+++ b/src/components/screens/IndexScreen/IndexScreen.js
@@ -39,11 +39,11 @@ const Placeholder = styled(PlaceholderAspectRatio)`
   }
 `;
 
-export function PureIndexScreen({ data: { gitHubRepoData, allMediumPost }, ...props }) {
+export function PureIndexScreen({ data: { gitHubRepoData }, ...props }) {
   const { ogImage, urls = {} } = useSiteMetadata();
   const { home, docs = {} } = urls;
   return (
-    <PageLayout allMediumPost={allMediumPost} {...props}>
+    <PageLayout {...props}>
       <SocialGraph
         title="Storybook: UI component explorer for frontend developers"
         desc="Storybook is an open source tool for developing UI components in isolation for React, Vue, and Angular. It makes building stunning UIs organized and efficient."
@@ -260,18 +260,6 @@ export default function IndexScreen(props) {
             url
             author
             name
-          }
-          allMediumPost(sort: { fields: [createdAt], order: DESC }, limit: 3) {
-            edges {
-              node {
-                id
-                title
-                virtuals {
-                  subtitle
-                }
-                uniqueSlug
-              }
-            }
           }
         }
       `}

--- a/src/components/screens/IndexScreen/IndexScreen.stories.js
+++ b/src/components/screens/IndexScreen/IndexScreen.stories.js
@@ -3,11 +3,10 @@ import { storiesOf } from '@storybook/react';
 
 import { PureIndexScreen } from './IndexScreen';
 import { gitHubRepoData } from './Hero.stories';
-import { allMediumPost } from '../../layout/Footer.stories';
 
 storiesOf('Frontpage|screens/IndexScreen/IndexScreen', module).add(
   'default',
-  () => <PureIndexScreen data={{ gitHubRepoData, allMediumPost }} />,
+  () => <PureIndexScreen data={{ gitHubRepoData }} />,
   {
     chromatic: { viewports: [320, 1200] },
   }

--- a/src/components/screens/NotFoundScreen/NotFoundScreen.js
+++ b/src/components/screens/NotFoundScreen/NotFoundScreen.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import styled from 'styled-components';
-import { StaticQuery, graphql } from 'gatsby';
+import { StaticQuery } from 'gatsby';
 
 import { Link, styles } from '@storybook/design-system';
 import PageLayout from '../../layout/PageLayout';
@@ -22,11 +22,11 @@ const Features = styled(FeaturesLayout)`
   }
 `;
 
-export function PureNotFoundScreen({ data: { allMediumPost }, ...props }) {
+export function PureNotFoundScreen({ ...props }) {
   const { urls = {} } = useSiteMetadata();
   const { gitHub = {}, chat } = urls;
   return (
-    <PageLayout allMediumPost={allMediumPost} {...props}>
+    <PageLayout {...props}>
       <Helmet>
         <meta name="robots" content="noindex" />
       </Helmet>
@@ -66,26 +66,5 @@ PureNotFoundScreen.propTypes = {
 };
 
 export default function NotFoundScreen(props) {
-  return (
-    <StaticQuery
-      query={graphql`
-        query NotFoundScreenQuery {
-          allMediumPost(sort: { fields: [createdAt], order: DESC }, limit: 3) {
-            edges {
-              node {
-                id
-                title
-                virtuals {
-                  subtitle
-                }
-                medium_id
-                uniqueSlug
-              }
-            }
-          }
-        }
-      `}
-      render={data => <PureNotFoundScreen data={data} {...props} />}
-    />
-  );
+  return <StaticQuery render={data => <PureNotFoundScreen data={data} {...props} />} />;
 }

--- a/src/components/screens/NotFoundScreen/NotFoundScreen.stories.js
+++ b/src/components/screens/NotFoundScreen/NotFoundScreen.stories.js
@@ -3,8 +3,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { PureNotFoundScreen } from './NotFoundScreen';
-import { allMediumPost } from '../../layout/Footer.stories';
 
 storiesOf('Frontpage|screens/NotFoundScreen/NotFoundScreen', module).add('default', () => (
-  <PureNotFoundScreen data={{ allMediumPost }} />
+  <PureNotFoundScreen />
 ));

--- a/src/components/screens/SupportScreen/SupportScreen.js
+++ b/src/components/screens/SupportScreen/SupportScreen.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { StaticQuery, graphql } from 'gatsby';
 
 import { Link, styles } from '@storybook/design-system';
 import PageLayout from '../../layout/PageLayout';
@@ -23,11 +22,11 @@ const Features = styled(FeaturesLayout)`
   }
 `;
 
-export function PureSupportScreen({ data: { allMediumPost }, ...props }) {
+export function PureSupportScreen({ ...props }) {
   const { title, ogImage, urls = {} } = useSiteMetadata();
   const { home, chat, docs = {}, gitHub = {} } = urls;
   return (
-    <PageLayout allMediumPost={allMediumPost} {...props}>
+    <PageLayout {...props}>
       <SocialGraph
         title={`Support | ${title}`}
         desc="Get answers to your Storybook questions from the thriving community and maintainers. Developers of all skill levels welcome."
@@ -79,26 +78,5 @@ PureSupportScreen.propTypes = {
 };
 
 export default function SupportScreen(props) {
-  return (
-    <StaticQuery
-      query={graphql`
-        query SupportScreenQuery {
-          allMediumPost(sort: { fields: [createdAt], order: DESC }, limit: 3) {
-            edges {
-              node {
-                id
-                title
-                virtuals {
-                  subtitle
-                }
-                medium_id
-                uniqueSlug
-              }
-            }
-          }
-        }
-      `}
-      render={data => <PureSupportScreen data={data} {...props} />}
-    />
-  );
+  return <PureSupportScreen {...props} />;
 }

--- a/src/components/screens/SupportScreen/SupportScreen.stories.js
+++ b/src/components/screens/SupportScreen/SupportScreen.stories.js
@@ -3,11 +3,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { PureSupportScreen } from './SupportScreen';
-import { allMediumPost } from '../../layout/Footer.stories';
 
 storiesOf('Frontpage|screens/SupportScreen/SupportScreen', module).add(
   'default',
-  () => <PureSupportScreen data={{ allMediumPost }} />,
+  () => <PureSupportScreen />,
   {
     chromatic: { viewports: [320, 1200] },
   }

--- a/src/components/screens/TeamScreen/TeamScreen.js
+++ b/src/components/screens/TeamScreen/TeamScreen.js
@@ -60,10 +60,10 @@ const contributors = [
   },
 ];
 
-export function PureTeamScreen({ data: { gitHubRepoData, allMediumPost }, ...props }) {
+export function PureTeamScreen({ data: { gitHubRepoData }, ...props }) {
   const { title, ogImage, urls = {} } = useSiteMetadata();
   return (
-    <PageLayout allMediumPost={allMediumPost} {...props}>
+    <PageLayout {...props}>
       <SocialGraph
         title={`Team | ${title}`}
         desc="Storybook is maintained by hundreds of contributors worldwide and guided by a steering committee."
@@ -150,19 +150,6 @@ export default function TeamScreen({ ...props }) {
           gitHubRepoData {
             contributorCount
             url
-          }
-          allMediumPost(sort: { fields: [createdAt], order: DESC }, limit: 3) {
-            edges {
-              node {
-                id
-                title
-                virtuals {
-                  subtitle
-                }
-                medium_id
-                uniqueSlug
-              }
-            }
           }
         }
       `}

--- a/src/components/screens/TeamScreen/TeamScreen.js
+++ b/src/components/screens/TeamScreen/TeamScreen.js
@@ -28,7 +28,7 @@ const contributors = [
   },
   {
     name: 'Kai Röder',
-    avatarUrl: 'https://pbs.twimg.com/profile_images/1060789281667670016/Zrfw467n_bigger.jpg',
+    avatarUrl: 'https://pbs.twimg.com/profile_images/1167896480373362689/CRgdWRVh.jpg',
   },
   {
     name: 'Chak Shun Yu',

--- a/src/components/screens/TeamScreen/TeamScreen.stories.js
+++ b/src/components/screens/TeamScreen/TeamScreen.stories.js
@@ -4,11 +4,10 @@ import { storiesOf } from '@storybook/react';
 
 import { PureTeamScreen } from './TeamScreen';
 import { gitHubRepoData } from '../IndexScreen/Hero.stories';
-import { allMediumPost } from '../../layout/Footer.stories';
 
 storiesOf('Frontpage|screens/TeamScreen/TeamScreen', module).add(
   'default',
-  () => <PureTeamScreen data={{ gitHubRepoData, allMediumPost }} />,
+  () => <PureTeamScreen data={{ gitHubRepoData }} />,
   {
     chromatic: { viewports: [320, 1200] },
   }

--- a/src/components/screens/UseCasesScreen/UseCasesScreen.js
+++ b/src/components/screens/UseCasesScreen/UseCasesScreen.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { StaticQuery, graphql } from 'gatsby';
 
 import { styles } from '@storybook/design-system';
 import PageLayout from '../../layout/PageLayout';
@@ -63,10 +62,10 @@ const DesignSystemWrapper = styled.div`
   }
 `;
 
-export function PureUseCasesScreen({ data: { allMediumPost }, ...props }) {
+export function PureUseCasesScreen({ ...props }) {
   const { title, ogImage, urls = {} } = useSiteMetadata();
   return (
-    <PageLayout allMediumPost={allMediumPost} {...props}>
+    <PageLayout {...props}>
       <SocialGraph
         title={`Use cases | ${title}`}
         desc="See how thousands of teams around the world use Storybook to build production UIs faster."
@@ -239,26 +238,5 @@ PureUseCasesScreen.propTypes = {
 };
 
 export default function UseCasesScreen(props) {
-  return (
-    <StaticQuery
-      query={graphql`
-        query UseCasesScreenQuery {
-          allMediumPost(sort: { fields: [createdAt], order: DESC }, limit: 3) {
-            edges {
-              node {
-                id
-                title
-                virtuals {
-                  subtitle
-                }
-                medium_id
-                uniqueSlug
-              }
-            }
-          }
-        }
-      `}
-      render={data => <PureUseCasesScreen data={data} {...props} />}
-    />
-  );
+  return <PureUseCasesScreen {...props} />;
 }

--- a/src/components/screens/UseCasesScreen/UseCasesScreen.stories.js
+++ b/src/components/screens/UseCasesScreen/UseCasesScreen.stories.js
@@ -3,11 +3,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { PureUseCasesScreen } from './UseCasesScreen';
-import { allMediumPost } from '../../layout/Footer.stories';
 
 storiesOf('Frontpage|screens/UseCasesScreen/UseCasesScreen', module).add(
   'default',
-  () => <PureUseCasesScreen data={{ allMediumPost }} />,
+  () => <PureUseCasesScreen />,
   {
     chromatic: { viewports: [320, 1200] },
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,7 +1231,6 @@
 "@storybook/design-system@^0.0.41":
   version "0.0.41"
   resolved "https://registry.yarnpkg.com/@storybook/design-system/-/design-system-0.0.41.tgz#0777f3d1afcb4024abc4994e283a93e8577a40ea"
-  integrity sha512-ERjGjeBaB/VVgydQ5S6npb6/76DCF1ry04GV3CjWfeOfwYfHummf8TjY2Q50maCmdfU/F5SAiy3EoZ48kftU/A==
   dependencies:
     global "^4.3.2"
     keycode "^2.2.0"
@@ -2199,13 +2198,6 @@ axios@0.17.1:
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"
   dependencies:
     follow-redirects "^1.2.5"
-    is-buffer "^1.1.5"
-
-axios@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  dependencies:
-    follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
 
 axobject-query@^2.0.2:
@@ -4826,14 +4818,12 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
 eslint-utils@^1.3.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
-  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
   dependencies:
     eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
-  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@^4.0.0:
   version "4.19.1"
@@ -5501,7 +5491,7 @@ focus-lock@^0.6.0:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.2.tgz#d8ac9dbc46250779789c3e6f43d978c7dfa59dcd"
 
-follow-redirects@^1.0.0, follow-redirects@^1.2.5, follow-redirects@^1.3.0:
+follow-redirects@^1.0.0, follow-redirects@^1.2.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
   dependencies:
@@ -5520,7 +5510,6 @@ for-in@^0.1.3:
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
-  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
 for-own@^0.1.3:
   version "0.1.5"
@@ -5791,7 +5780,6 @@ gatsby-plugin-styled-components@^3.0.4:
 gatsby-plugin-web-font-loader@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-web-font-loader/-/gatsby-plugin-web-font-loader-1.0.4.tgz#c50bdb0c1980110b3fd213a5be70feb2459514c3"
-  integrity sha512-3c39bX9CcsYJQFhhmTyjuMJSqpld2rX+HsTOxP9k1PKFR4Rvo3lpzBW4d1tVpmUesR8BNL6u9eHT7/XksS1iog==
   dependencies:
     babel-runtime "^6.26.0"
     webfontloader "^1.6.28"
@@ -5830,13 +5818,6 @@ gatsby-source-github-repo@^1.0.4:
   dependencies:
     jsdom "^14.0.0"
     node-fetch "^2.3.0"
-
-gatsby-source-medium@^2.0.3:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/gatsby-source-medium/-/gatsby-source-medium-2.0.7.tgz#de5695487e21d43130a6202098782c85af988740"
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    axios "^0.18.0"
 
 gatsby-telemetry@^1.0.7:
   version "1.0.7"
@@ -7049,7 +7030,6 @@ is-extendable@^0.1.0, is-extendable@^0.1.1:
 is-extendable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
-  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
     is-plain-object "^2.0.4"
 
@@ -7175,7 +7155,6 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
-  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
 
@@ -7304,7 +7283,6 @@ isobject@^2.0.0:
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
@@ -7570,7 +7548,6 @@ kebab-hash@^0.1.2:
 keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
-  integrity sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=
 
 keyv@3.0.0:
   version "3.0.0"
@@ -7750,12 +7727,10 @@ lockfile@^1.0.4:
 lodash-es@^4.17.11:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.14.tgz#12a95a963cc5955683cee3b74e85458954f37ecc"
-  integrity sha512-7zchRrGa8UZXjD/4ivUWP1867jDkhzTG2c/uj739utSd7O/pFFdxspCemIFKEEjErbcqRzn8nKnGsi7mvTgRPA==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -7804,12 +7779,10 @@ lodash.memoize@^4.1.2:
 lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.mergewith@^4.6.1:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.pick@^4.4.0:
   version "4.4.0"
@@ -7826,7 +7799,6 @@ lodash.sortby@^4.7.0:
 lodash.template@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
   dependencies:
     lodash._reinterpolate "^3.0.0"
     lodash.templatesettings "^4.0.0"
@@ -7834,7 +7806,6 @@ lodash.template@^4.4.0:
 lodash.templatesettings@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
@@ -8247,7 +8218,6 @@ mitt@^1.1.2:
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
-  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -9735,7 +9705,6 @@ pretty-hrtime@^1.0.3:
 prismjs@1.13.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.13.0.tgz#edcc14a90bbd72a03e5ffd2bab81a04c79a607a6"
-  integrity sha512-0/1Fiyg3MCzepo6t6Wzx2Ef4nftGKeQIv+Z6LO38RcYJN5QV2ePHh8W41ZkFn57B++6BnglF6fCiJ9b80YlzkQ==
   optionalDependencies:
     clipboard "^2.0.0"
 
@@ -12366,7 +12335,6 @@ web-namespaces@^1.1.2:
 webfontloader@^1.6.28:
   version "1.6.28"
   resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
-  integrity sha1-23hhKSU8tujq5UwvsF+HCvZnW64=
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
The Medium integration [no longer works](https://github.com/gatsbyjs/gatsby/issues/17335) as of a few days ago. This is causing our CircleCI and Netlify builds to error out without running.

In the meantime this PR removes medium so we can deploy builds and visual test again.

We'll have to find another way to add the Medium functionality back at a later point. Could definitely use help on this 🙏cc @dakebl @Keraito @lucas-carl

