### PR TITLE
Add Storybook Addon GraphCMS to addons Gallery

### DIFF
--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -292,6 +292,11 @@ export function PureAddonScreen({ ...props }) {
           desc="Manage state inside a story. Update components when this state changes. Wrap the story in a function call to setup state management. The story can modify state properties with the provided store. The addon provides a panel to view and reset state."
           addonUrl="https://github.com/dump247/storybook-state/"
         />
+        <AddonItem
+          title="GraphCMS"
+          desc="Put GraphQL queries to your stories and either see the default formatted output or pass received data to your Components. Can be connected to any GraphQL endpoint but have additional features for GraphCMS projects."
+          addonUrl="https://github.com/focusreactive/storybook-addon-graphcms"
+        />
 
         <Subheader>Style</Subheader>
         <AddonItem


### PR DESCRIPTION
Hey
we've created this addon for our projects at FocusReactive and want to share it with the community
https://github.com/focusreactive/storybook-addon-graphcms

>Put GraphQL queries to your stories and either see the default formatted output or pass received data to your Components. Can be connected to any GraphQL endpoint but have additional features for GraphCMS projects.