### PR TITLE
Add storybook-addon-themes to addon list

### DIFF
--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -349,6 +349,11 @@ export function PureAddonScreen({ ...props }) {
           desc="Select between themes and tweek them directly in a panel."
           addonUrl="https://github.com/jeslage/storybook-addon-theme-playground"
         />
+        <AddonItem
+          title="Themes"
+          desc="Allows you to change the theme based on the css class name and adds a theme selection control to storybook panel."
+          addonUrl="https://github.com/tonai/storybook-addon-themes"
+        />
 
         <Subheader>Design</Subheader>
         <AddonItem

--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -351,7 +351,7 @@ export function PureAddonScreen({ ...props }) {
         />
         <AddonItem
           title="Themes"
-          desc="Allows you to change the theme based on the css class name and adds a theme selection control to storybook panel."
+          desc="Allows you to change the theme based on a css class name and adds a theme selection control to the Storybook panel."
           addonUrl="https://github.com/tonai/storybook-addon-themes"
         />
 


### PR DESCRIPTION
Related to the following issue https://github.com/storybookjs/storybook/issues/7052
Only the https://storybook.js.org/docs/addons/addon-gallery/ page was updated by the https://github.com/storybookjs/storybook/pull/7465 pull request
This Pull request is an update for the https://storybook.js.org/addons/ page.