### PR TITLE
Add Matrix to test addons

### DIFF
--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -262,6 +262,11 @@ export function PureAddonScreen({ ...props }) {
           desc="Resize your responsive viewports dynamically with a draggable handle, exact px/em width inputs, or with one-click preset size buttons."
           addonUrl="https://github.com/DEGJS/storybook-addon-taffy"
         />
+        <AddonItem
+          title="Matrix"
+          desc="Rendering components with a matrix of props. This addon can also be used with storyshots."
+          addonUrl="https://github.com/tomoya/storybook-addon-matrix"
+        />
 
         <Subheader>Code</Subheader>
         <AddonItem


### PR DESCRIPTION
As far as I know, props combinations no longer supported.
Ref https://github.com/evgenykochetkov/react-storybook-addon-props-combinations/issues/28

That's why I created the Matrix addon as an alternative.