### PR TITLE
Remove default Netlify headers

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -78,7 +78,18 @@ module.exports = {
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',
-    'gatsby-plugin-netlify',
+    {
+      resolve: 'gatsby-plugin-netlify',
+      options: {
+        headers: {
+          // Remove `X-Frame-Options: DENY` default header so that the release notes can
+          // be served in an iframe.
+          '/*': ['X-XSS-Protection: 1; mode=block', 'X-Content-Type-Options: nosniff'],
+        },
+        // Do not use the default security headers. Use those we have defined above.
+        mergeSecurityHeaders: false,
+      },
+    },
     'gatsby-plugin-remove-trailing-slashes',
   ],
 };


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/11484

`gatsby-plugin-netlify` was adding an `X-Frame-Options: DENY` header by default which was causing our iframed page to break inside of Storybook when trying to view the release notes. My ideal use case here is to just disable the `X-Frame-Options` header for the iframe paths, but that doesn't seem to be possible (I tried a few different ways) so I just removed that header for all pages & added back the other headers that Gatsby was adding.

I tested this in SB locally by changing the release notes iframe URL to the deploy preview URL generated here.

Ref: https://www.gatsbyjs.org/packages/gatsby-plugin-netlify/