### PR TITLE
Add `gatsby-remark-autolink-headers`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,6 +72,7 @@ module.exports = {
             },
           },
           'gatsby-remark-copy-linked-files',
+          `gatsby-remark-autolink-headers`,
         ],
       },
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gatsby-plugin-styled-components": "^3.3.9",
     "gatsby-plugin-typescript": "^2.4.13",
     "gatsby-plugin-web-font-loader": "^1.0.4",
+    "gatsby-remark-autolink-headers": "^2.3.11",
     "gatsby-remark-copy-linked-files": "^2.3.11",
     "gatsby-remark-images": "^3.3.18",
     "gatsby-remark-link-rewrite": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9312,6 +9312,17 @@ gatsby-recipes@^0.1.50:
     ws "^7.3.0"
     xstate "^4.11.0"
 
+gatsby-remark-autolink-headers@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.3.11.tgz#13f9e6354b73d0088896dad8bea8e35b5a85ba43"
+  integrity sha512-jYGgZ+NTbVxJmyS6z1oojWxOR12R7MGl4jM5aOXSmPuTSo8gbpm3aW7l5XMyud5fDDdP3xfbYuTX4RvBUWrx7g==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    github-slugger "^1.3.0"
+    lodash "^4.17.15"
+    mdast-util-to-string "^1.1.0"
+    unist-util-visit "^1.4.1"
+
 gatsby-remark-copy-linked-files@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.3.11.tgz#d89880c08aa6f68fc6dd765343c8ff4c5d13edf9"
@@ -9697,7 +9708,7 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
-github-slugger@^1.2.1:
+github-slugger@^1.2.1, github-slugger@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"
   integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==


### PR DESCRIPTION
Solves https://github.com/chromaui/learnstorybook.com/issues/347 very nicely indeed!

@jonniebigodes -- note that the links (in the source markdown) **need to have a trailing `.md`** (before the `#`) like I POC-ed in [this branch](https://github.com/storybookjs/storybook/tree/test-update-link)

Note the link changed there in https://github.com/storybookjs/storybook/commit/dcff96b5c821c5d38fcb062469e098546ff69309 is the "custom webpack configuration" link. Note that it works both:

1. On GH directly: https://github.com/storybookjs/storybook/blob/test-update-link/docs/configure/overview.md
2. In development gatsby (on this branch if you have [that branch](https://github.com/storybookjs/storybook/tree/test-update-link) checked out in the monorepo).
3. In built gatsby (on this branch similarly).

Note there is some kind of negative interaction between our styles and those of [`gatsby-remark-autolink-headers`](https://www.gatsbyjs.org/packages/gatsby-remark-autolink-headers/) -- there are lots of options to customize this -- I will leave that up to others ;)