### PR TITLE
Added a basic feature snippets concept

### DIFF
--- a/scripts/extract-monorepo-docs.sh
+++ b/scripts/extract-monorepo-docs.sh
@@ -3,7 +3,7 @@
 # Pull the monorepo docs from the branch specified as the first argument, or `master`.
 
 MONOREPO_CODELOAD_URL='https://codeload.github.com/storybookjs/storybook/tar.gz'
-BRANCH=${1:-6.0-docs}
+BRANCH=${1:-feautre-snippets}
 TAR_NAME="storybook-$BRANCH"
 REPO_SUBDIR='docs/'
 REPO_DEPTH=2 # number of dirs + 1

--- a/scripts/extract-monorepo-docs.sh
+++ b/scripts/extract-monorepo-docs.sh
@@ -3,7 +3,7 @@
 # Pull the monorepo docs from the branch specified as the first argument, or `master`.
 
 MONOREPO_CODELOAD_URL='https://codeload.github.com/storybookjs/storybook/tar.gz'
-BRANCH=${1:-feautre-snippets}
+BRANCH=${1:-feature-snippets}
 TAR_NAME="storybook-$BRANCH"
 REPO_SUBDIR='docs/'
 REPO_DEPTH=2 # number of dirs + 1

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -20,6 +20,7 @@ import useSiteMetadata from '../../lib/useSiteMetadata';
 import { mdFormatting } from '../../../styles/formatting';
 import buildPathWithFramework from '../../../util/build-path-with-framework';
 import stylizeFramework from '../../../util/stylize-framework';
+import { FeatureSnippets } from './FeatureSnippets';
 
 const { color, spacing, typography } = styles;
 
@@ -76,7 +77,9 @@ function DocsScreen({ data, pageContext }) {
   const CodeSnippetsWithCurrentFramework = useMemo(() => {
     return (props) => <CodeSnippets currentFramework={framework} {...props} />;
   }, [framework]);
-
+  const FeatureSnippetsWithCurrentFramework = useMemo(() => {
+    return (props) => <FeatureSnippets currentFramework={framework} {...props} />;
+  }, [framework]);
   const FrameworkSupportTableWithFeaturesAndCurrentFramework = useMemo(() => {
     return ({ frameworks }) => (
       <FrameworkSupportTable
@@ -125,6 +128,7 @@ function DocsScreen({ data, pageContext }) {
         <MDXProvider
           components={{
             CodeSnippets: CodeSnippetsWithCurrentFramework,
+            FeatureSnippets: FeatureSnippetsWithCurrentFramework,
             FrameworkSupportTable: FrameworkSupportTableWithFeaturesAndCurrentFramework,
           }}
         >

--- a/src/components/screens/DocsScreen/FeatureSnippets.tsx
+++ b/src/components/screens/DocsScreen/FeatureSnippets.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { basename } from 'path';
+
+const FALLBACK = 'fallback';
+
+export function PureFeatureSnippets({ framework, snippetsByFramework }) {
+  let Snippet = snippetsByFramework[framework];
+  if (!Snippet) {
+    Snippet = snippetsByFramework[FALLBACK];
+    if (!Snippet) {
+      // TODO: we should add a "to help enable this feature for <Framework />, do Y"
+      return null;
+    }
+  }
+
+  return <Snippet />;
+}
+
+export function FeatureSnippets({ currentFramework, paths }) {
+  const [snippetsByFramework, setSnippetsByFramework] = useState({});
+  useEffect(() => {
+    const fetchSnippetsByFramework = async () => {
+      const entries = await Promise.all(
+        paths.map(async (path) => {
+          // See comment in CodeSnippets
+          const { default: ModuleComponent } = await import(`../../../content/docs/${path}`);
+
+          const parts = basename(path, '.mdx').split('-');
+          const framework = parts[parts.length - 1];
+          return [framework, ModuleComponent];
+        })
+      );
+
+      setSnippetsByFramework(Object.fromEntries(entries));
+    };
+    fetchSnippetsByFramework();
+  }, []);
+
+  return (
+    <PureFeatureSnippets framework={currentFramework} snippetsByFramework={snippetsByFramework} />
+  );
+}


### PR DESCRIPTION
Goes with https://github.com/storybookjs/storybook/pull/11849

Very basic mechanism to add text entries per "feature" with a fallback to a generic "help us add this feature, here's the workaround.

@kylesuss can you take a look at the implementation. It's pretty simple right now.

@shilman can you look at the [input](https://github.com/storybookjs/storybook/pull/11849) and [output](https://deploy-preview-132--storybook-frontpage.netlify.app/docs/react/essentials/controls)? Do you think it should be an aside or something? That could be done on a per-snippet basis (inside the MDX) or always (in the component).