### PR TITLE
Fix copy paste issue for frameworks with missing snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
-    "@storybook/design-system": "^5.1.21",
+    "@storybook/design-system": "^5.1.22",
     "core-js": "^2.6.11",
     "gatsby": "^2.24.27",
     "gatsby-cli": "2.12.58",

--- a/src/components/screens/DocsScreen/CodeSnippets.stories.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Highlight } from '@storybook/design-system';
 
-import { PureCodeSnippets, ModuleComponentWithMessage, TabLabel } from './CodeSnippets';
+import { PureCodeSnippets, MissingMessage, TabLabel } from './CodeSnippets';
 import { mdFormatting } from '../../../styles/formatting';
 import compiledMDX from '../../../../.storybook/compiled-mdx';
 
@@ -35,13 +35,7 @@ function TSModuleComponent() {
 const snippets = [
   {
     id: `react-js`,
-    Snippet: () => (
-      <ModuleComponentWithMessage
-        ModuleComponent={JSModuleComponent}
-        currentFramework="react"
-        withMissingMessaging={false}
-      />
-    ),
+    Snippet: JSModuleComponent,
     framework: 'react',
     syntax: 'js',
     renderTabLabel: ({ isActive }) => (
@@ -50,13 +44,7 @@ const snippets = [
   },
   {
     id: `react-ts`,
-    Snippet: () => (
-      <ModuleComponentWithMessage
-        ModuleComponent={TSModuleComponent}
-        currentFramework="react"
-        withMissingMessaging={false}
-      />
-    ),
+    Snippet: TSModuleComponent,
     framework: 'react',
     syntax: 'ts',
     renderTabLabel: ({ isActive }) => (
@@ -74,13 +62,8 @@ const snippetsWithoutBadges = snippets.map((snippet, index) => ({
 
 const snippetsWithMissingMessaging = snippets.map((snippet, index) => ({
   ...snippet,
-  Snippet: () => (
-    <ModuleComponentWithMessage
-      ModuleComponent={TSModuleComponent}
-      currentFramework="angular"
-      withMissingMessaging
-    />
-  ),
+  PreSnippet: () => <MissingMessage currentFramework="angular" />,
+  Snippet: TSModuleComponent,
 }));
 
 const Wrapper = styled.div`

--- a/src/components/screens/DocsScreen/CodeSnippets.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets.tsx
@@ -66,7 +66,7 @@ export function PureCodeSnippets(props) {
   return <DesignSystemCodeSnippets className={CODE_SNIPPET_CLASSNAME} {...props} />;
 }
 
-const MissingMessaging = styled.div`
+const MissingMessagingWrapper = styled.div`
   background-color: #fdf5d3;
   padding: 10px 16px;
   border-bottom: 1px solid ${color.border};
@@ -74,29 +74,20 @@ const MissingMessaging = styled.div`
   line-height: 20px;
 `;
 
-export function ModuleComponentWithMessage({
-  currentFramework,
-  ModuleComponent,
-  withMissingMessaging,
-}) {
+export function MissingMessage({ currentFramework }) {
   return (
-    <>
-      {withMissingMessaging && (
-        <MissingMessaging>
-          This snippet doesnt exist for {stylizeFramework(currentFramework)} yet.{' '}
-          <Link
-            appearance="secondary"
-            href="https://github.com/storybookjs/storybook/tree/next/docs"
-            target="_blank"
-            rel="noopener"
-          >
-            Contribute it in a PR now
-          </Link>
-          . In the meantime, here’s the {stylizeFramework(DEFAULT_FRAMEWORK)} snippet.
-        </MissingMessaging>
-      )}
-      <ModuleComponent />
-    </>
+    <MissingMessagingWrapper>
+      This snippet doesnt exist for {stylizeFramework(currentFramework)} yet.{' '}
+      <Link
+        appearance="secondary"
+        href="https://github.com/storybookjs/storybook/tree/next/docs"
+        target="_blank"
+        rel="noopener"
+      >
+        Contribute it in a PR now
+      </Link>
+      . In the meantime, here’s the {stylizeFramework(DEFAULT_FRAMEWORK)} snippet.
+    </MissingMessagingWrapper>
   );
 }
 
@@ -128,13 +119,10 @@ export function CodeSnippets({ paths, currentFramework, ...rest }) {
 
           return {
             id: `${framework}-${syntax}`,
-            Snippet: () => (
-              <ModuleComponentWithMessage
-                ModuleComponent={ModuleComponent}
-                currentFramework={currentFramework}
-                withMissingMessaging={!!defaultFrameworkPaths}
-              />
-            ),
+            PreSnippet: defaultFrameworkPaths
+              ? () => <MissingMessage currentFramework={currentFramework} />
+              : undefined,
+            Snippet: ModuleComponent,
             framework,
             syntax,
             renderTabLabel: ({ isActive }) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,10 +2930,10 @@
   dependencies:
     lodash "^4.17.15"
 
-"@storybook/design-system@^5.1.21":
-  version "5.1.21"
-  resolved "https://registry.yarnpkg.com/@storybook/design-system/-/design-system-5.1.21.tgz#a8aa2d749a4752b79a904947701524a48e92e96e"
-  integrity sha512-Rd8nVG7cl1MOmZEzfVAbqncZnaW9PIDaH8oM9CYJFh0i3e5MEDFXKEl7abzuWe1jkGwBWt5W89qQuOAemHyS7A==
+"@storybook/design-system@^5.1.22":
+  version "5.1.22"
+  resolved "https://registry.yarnpkg.com/@storybook/design-system/-/design-system-5.1.22.tgz#bd97a5e9eaf9cf98ae9cdc46bd3a1c7dc6ec58fa"
+  integrity sha512-4JUbFIU4yhLl3OgF6XqOwUlWMy2F2PSKPcMHDLuc3snOT5LmkaAckM6Kc3m7xfdkP7FVCNea7KHwbRjUIUk5pw==
   dependencies:
     copy-to-clipboard "^3.3.1"
     polished "^3.6.4"


### PR DESCRIPTION
I noticed that the frameworks w/ missing snippets had the messaging about the snippet being missing in the copied text! I added a slot to separate the snippet from this "pre-snippet" content so that only the snippet is copied.