### PR TITLE
Generate versions file on build

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -231,7 +231,7 @@ exports.createPages = ({ actions, graphql }) => {
 };
 
 function getVersionData(distTag) {
-  const versionFile = `${__dirname}/versions/${distTag}.json`;
+  const versionFile = `./src/content/docs/versions/${distTag}.json`;
   if (!fs.existsSync(versionFile)) {
     return null;
   }
@@ -245,7 +245,7 @@ function generateVersionsFile() {
   const latest = getVersionData('latest');
   const next = getVersionData('next');
   const data = { ...latest, ...next };
-  fs.writeFileSync(`${__dirname}/public/versions.json`, JSON.stringify(data));
+  fs.writeFileSync('./public/versions.json', JSON.stringify(data));
 }
 
 exports.onPostBuild = () => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 
 const { createFilePath } = require(`gatsby-source-filesystem`);
@@ -227,4 +228,26 @@ exports.createPages = ({ actions, graphql }) => {
       }
     );
   });
+};
+
+function getVersionData(distTag) {
+  const versionFile = `${__dirname}/versions/${distTag}.json`;
+  if (!fs.existsSync(versionFile)) {
+    return null;
+  }
+  const data = {
+    [distTag]: JSON.parse(fs.readFileSync(versionFile)),
+  };
+  return data;
+}
+
+function generateVersionsFile() {
+  const latest = getVersionData('latest');
+  const next = getVersionData('next');
+  const data = { ...latest, ...next };
+  fs.writeFileSync(`${__dirname}/public/versions.json`, JSON.stringify(data));
+}
+
+exports.onPostBuild = () => {
+  generateVersionsFile();
 };


### PR DESCRIPTION
This code builds `versions.json`, which is what storybook's version update check requests.

This had previously.been built inside the storybook monorepo. The new code pulls over `versions/x.json` (x = `latest`/`next`) and assembles them into a single `versions.json` file on build.