### PR TITLE
Use GatsbyLink for framework support table header

### DIFF
--- a/src/components/screens/DocsScreen/FrameworkSupportTable.tsx
+++ b/src/components/screens/DocsScreen/FrameworkSupportTable.tsx
@@ -30,7 +30,7 @@ export const FrameworkSupportTable = ({ currentFramework, frameworks, featureGro
           <th aria-label="frameworks" />
           {frameworks.map((framework) => (
             <th>
-              <a href={`/docs/${framework}`}>{stylizeFramework(framework)}</a>
+              <GatsbyLink to={`/docs/${framework}`}>{stylizeFramework(framework)}</GatsbyLink>
             </th>
           ))}
         </tr>


### PR DESCRIPTION
so the page doesn't refresh when you click the link.