### PR TITLE
Remove react-hanger, fix NpmDownloadCount effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-github-button": "^0.1.11",
-    "react-hanger": "^1.2.0",
     "react-helmet": "^5.2.1",
     "react-lazyload": "^2.6.5",
     "recompose": "^0.30.0",

--- a/src/components/layout/NpmDownloadCount.js
+++ b/src/components/layout/NpmDownloadCount.js
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { fetch, window } from 'global';
-import { useOnMount, useSetState } from 'react-hanger';
 import useSiteMetadata from '../lib/useSiteMetadata';
 
 import { Cardinal } from '../basics';
@@ -19,7 +18,7 @@ const fetchNpmDownloads = async (npmApiUrls) => {
 };
 
 const NpmDownloadCount = (props) => {
-  const { state, setState } = useSetState({ loading: true, npmDownloads: 0 });
+  const [state, setState] = useState({ loading: true, npmDownloads: 0 });
   const { urls = {} } = useSiteMetadata();
   const { npm, npmApi } = urls;
 
@@ -30,7 +29,7 @@ const NpmDownloadCount = (props) => {
     npmDownloadsDisplay = `${npmDownloadsFixed}m`;
   }
 
-  useOnMount(() => {
+  useEffect(() => {
     if (!window.sessionStorage.getItem('monthlyNpmDownloads')) {
       fetchNpmDownloads(npmApi).then((npmDownloadCount) => {
         setState({ loading: false, npmDownloads: npmDownloadCount });
@@ -42,7 +41,7 @@ const NpmDownloadCount = (props) => {
         npmDownloads: window.sessionStorage.getItem('monthlyNpmDownloads'),
       });
     }
-  });
+  }, []);
 
   return (
     <Cardinal

--- a/yarn.lock
+++ b/yarn.lock
@@ -17059,11 +17059,6 @@ react-github-button@^0.1.11:
   dependencies:
     prop-types "^15.5.10"
 
-react-hanger@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-hanger/-/react-hanger-1.2.0.tgz#26d3ccdebc7bd561640de6239fb9250a9c4834cd"
-  integrity sha512-YKMFa4wkWb8pvsxSX9F6atEpsvxfddbfyIv5TmReYs/0oWOZrGIYmVY95kQOX0bnsyy3xRSnjyv62+uZqzZrlQ==
-
 react-helmet-async@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.6.tgz#11c15c74e79b3f66670c73779bef3e0e352b1d4e"


### PR DESCRIPTION
No idea what `react-hanger` is, but we don't need it and the `useOnMount` hook was firing all the time, hence the overuse of CPU on the homepage.