### PR TITLE
Add docsearch meta tag for algolia to pick up

### DIFF
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -149,6 +149,7 @@ function DocsLayout({ children, data, pageContext, ...props }) {
       <GlobalStyle />
       <Helmet>
         <link rel="canonical" href={`${homepageUrl}${buildPathWithFramework(slug, 'react')}`} />
+        <meta name="docsearch:framework" content={framework} />
       </Helmet>
       <Wrapper>
         <Sidebar>


### PR DESCRIPTION
Step 1 to get this working:

https://docsearch.algolia.com/docs/required-configuration/#introduce-global-information-as-meta-tags