### PR TITLE
Integrate Algolia Docsearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ monorepo
 
 # Pulled from monorepo
 src/content/docs
+
+# Env vars
+.env.production
+.env.development

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Search within the docs is powered by [DocSearch](https://docsearch.algolia.com/)
 
 `GATSBY_ALGOLIA_API_KEY`
 
-In development and with local production builds, that environment variable can be configured with `.env` files as explaned [here](https://www.gatsbyjs.com/docs/environment-variables/#client-side-javascript). In deploy previews and production deploys, that variable is set with Netlify's build variables.
+In development and with local production builds, that environment variable can be configured with `.env` files as explaned [here](https://www.gatsbyjs.com/docs/environment-variables/#client-side-javascript). The `GATSBY_` prefix ensures that the variable is available in client-side code. In deploy previews and production deploys, that variable is set with Netlify's build variables.
 
 The site is crawled every 24 hours so any updates will be reflected in that amount of time.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Release notes are stored in the src/content/releases directory as `.md` files. T
 
 Within the release's `.md` file, frontmatter is used to create a page title, while the rest of the content is parsed using `gatsby-transformer-remark` and styled with selectors in `src/styles/formatting.js`.
 
+### Search
+
+Search within the docs is powered by [DocSearch](https://docsearch.algolia.com/). In order for this to work, an environment variable is required:
+
+`GATSBY_ALGOLIA_API_KEY`
+
+In development and with local production builds, that environment variable can be configured with `.env` files as explaned [here](https://www.gatsbyjs.com/docs/environment-variables/#client-side-javascript). In deploy previews and production deploys, that variable is set with Netlify's build variables.
+
+The site is crawled every 24 hours so any updates will be reflected in that amount of time.
+
 ## Tooling
 
 This project uses these tools to make our job easier.

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -130,9 +130,7 @@ function DocsLayout({ children, data, pageContext, ...props }) {
   } = useSiteMetadata();
   const { docsToc, framework } = pageContext;
   const [searchValue, setSearchValue] = useState('');
-  const [isSearchVisible, setSearchVisible] = useState(!!process.env.GATSBY_ALGOLIA_API_KEY);
-
-  useAlgoliaSearch({ hideSearchInput: () => setSearchVisible(false) });
+  const { isSearchVisible } = useAlgoliaSearch({ framework });
 
   const addLinkWrappers = (items) =>
     items.map((item) => ({

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import {
@@ -23,6 +23,7 @@ import useSiteMetadata from '../lib/useSiteMetadata';
 import buildPathWithFramework from '../../util/build-path-with-framework';
 import { FrameworkSelector } from '../screens/DocsScreen/FrameworkSelector';
 import stylizeFramework from '../../util/stylize-framework';
+import useAlgoliaSearch, { SEARCH_INPUT_ID } from '../../hooks/use-algolia-search';
 
 const { breakpoint, color, pageMargins, typography } = styles;
 const { GlobalStyle } = global;
@@ -128,6 +129,10 @@ function DocsLayout({ children, data, pageContext, ...props }) {
     urls: { homepageUrl },
   } = useSiteMetadata();
   const { docsToc, framework } = pageContext;
+  const [searchValue, setSearchValue] = useState('');
+  const [isSearchVisible, setSearchVisible] = useState(!!process.env.GATSBY_ALGOLIA_API_KEY);
+
+  useAlgoliaSearch({ hideSearchInput: () => setSearchVisible(false) });
 
   const addLinkWrappers = (items) =>
     items.map((item) => ({
@@ -150,6 +155,10 @@ function DocsLayout({ children, data, pageContext, ...props }) {
       <Helmet>
         <link rel="canonical" href={`${homepageUrl}${buildPathWithFramework(slug, 'react')}`} />
         <meta name="docsearch:framework" content={framework} />
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
+        />
       </Helmet>
       <Wrapper>
         <Sidebar>
@@ -161,16 +170,23 @@ function DocsLayout({ children, data, pageContext, ...props }) {
             {({ menu, allTopLevelMenusAreOpen, toggleAllOpen, toggleAllClosed }) => (
               <>
                 <SidebarControls>
-                  {/* TODO: Once search is ready, delete the div below and uncomment the Input */}
-                  <div style={{ flex: 'none', marginRight: 0 }} />
-                  {/* <Input
-                    id="search"
-                    label="Search"
-                    hideLabel
-                    icon="search"
-                    appearance="pill"
-                    placeholder="Search docs"
-                  /> */}
+                  {isSearchVisible ? (
+                    <Input
+                      id={SEARCH_INPUT_ID}
+                      label="Search"
+                      hideLabel
+                      icon="search"
+                      appearance="pill"
+                      placeholder="Search docs"
+                      value={searchValue}
+                      onChange={(event) => setSearchValue(event.target.value)}
+                    />
+                  ) : (
+                    <>
+                      {/* Placeholder to preserve styling given the input is missing. */}
+                      <div style={{ flex: 'none', marginRight: 0 }} />
+                    </>
+                  )}
                   {allTopLevelMenusAreOpen ? (
                     <WithTooltip
                       {...withTooltipProps}

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -85,6 +85,19 @@ const SidebarControls = styled.div`
       flex: 0 0 100%;
     }
   }
+
+  .algolia-autocomplete .ds-dropdown-menu {
+    font-size: 0.8em;
+  }
+
+  .algolia-autocomplete a {
+    text-decoration: none;
+    transition: transform 150ms ease-out, color 150ms ease-out;
+
+    &:hover {
+      transform: translateY(-1px);
+    }
+  }
 `;
 
 const Content = styled.div`

--- a/src/hooks/use-algolia-search.js
+++ b/src/hooks/use-algolia-search.js
@@ -1,17 +1,19 @@
 /* eslint-env browser */
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export const SEARCH_INPUT_ID = 'algolia-search';
 const SEARCH_LIBRARY_SCRIPT_ID = 'algolia-search-library';
 const SEARCH_INIT_SCRIPT_ID = 'algolia-search-init';
 
-export default ({ hideSearchInput } = {}) => {
+export default ({ framework }) => {
+  const [isSearchVisible, setSearchVisible] = useState(!!process.env.GATSBY_ALGOLIA_API_KEY);
+
   useEffect(() => {
     if (!process.env.GATSBY_ALGOLIA_API_KEY) return;
 
     const initSearch = () => {
       if (!window.docsearch) {
-        hideSearchInput();
+        setSearchVisible(false);
         return;
       }
 
@@ -20,21 +22,26 @@ export default ({ hideSearchInput } = {}) => {
           apiKey: process.env.GATSBY_ALGOLIA_API_KEY,
           indexName: 'storybook-js',
           inputSelector: `#${SEARCH_INPUT_ID}`,
+          algoliaOptions: { facetFilters: ['tags:docs', `framework:${framework}`] },
         });
       } catch (err) {
-        hideSearchInput();
+        setSearchVisible(false);
       }
     };
 
     const placedLibaryScript = document.querySelector(`#${SEARCH_LIBRARY_SCRIPT_ID}`);
 
-    if (!placedLibaryScript) {
+    if (placedLibaryScript) {
+      initSearch();
+    } else {
       const libraryScript = document.createElement('script');
       libraryScript.id = SEARCH_LIBRARY_SCRIPT_ID;
       libraryScript.onload = initSearch;
-      libraryScript.onError = hideSearchInput;
+      libraryScript.onerror = () => setSearchVisible(false);
       libraryScript.src = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js';
       document.body.appendChild(libraryScript);
     }
-  }, []);
+  }, [framework]);
+
+  return { isSearchVisible };
 };

--- a/src/hooks/use-algolia-search.js
+++ b/src/hooks/use-algolia-search.js
@@ -1,0 +1,40 @@
+/* eslint-env browser */
+import { useEffect } from 'react';
+
+export const SEARCH_INPUT_ID = 'algolia-search';
+const SEARCH_LIBRARY_SCRIPT_ID = 'algolia-search-library';
+const SEARCH_INIT_SCRIPT_ID = 'algolia-search-init';
+
+export default ({ hideSearchInput } = {}) => {
+  useEffect(() => {
+    if (!process.env.GATSBY_ALGOLIA_API_KEY) return;
+
+    const initSearch = () => {
+      if (!window.docsearch) {
+        hideSearchInput();
+        return;
+      }
+
+      try {
+        window.docsearch({
+          apiKey: process.env.GATSBY_ALGOLIA_API_KEY,
+          indexName: 'storybook-js',
+          inputSelector: `#${SEARCH_INPUT_ID}`,
+        });
+      } catch (err) {
+        hideSearchInput();
+      }
+    };
+
+    const placedLibaryScript = document.querySelector(`#${SEARCH_LIBRARY_SCRIPT_ID}`);
+
+    if (!placedLibaryScript) {
+      const libraryScript = document.createElement('script');
+      libraryScript.id = SEARCH_LIBRARY_SCRIPT_ID;
+      libraryScript.onload = initSearch;
+      libraryScript.onError = hideSearchInput;
+      libraryScript.src = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js';
+      document.body.appendChild(libraryScript);
+    }
+  }, []);
+};

--- a/src/hooks/use-algolia-search.js
+++ b/src/hooks/use-algolia-search.js
@@ -29,9 +29,9 @@ export default ({ framework }) => {
       }
     };
 
-    const placedLibaryScript = document.querySelector(`#${SEARCH_LIBRARY_SCRIPT_ID}`);
+    const placedLibraryScript = document.querySelector(`#${SEARCH_LIBRARY_SCRIPT_ID}`);
 
-    if (placedLibaryScript) {
+    if (placedLibraryScript) {
       initSearch();
     } else {
       const libraryScript = document.createElement('script');


### PR DESCRIPTION
Search for the docs, powered by Algolia Docsearch 🎉 

Available for testing on the deploy preview:
https://deploy-preview-160--storybook-frontpage.netlify.app/docs/react/get-started/introduction

You only get results for the framework you currently have selected. I think that makes sense, but is it unclear to anyone?