### PR TITLE
Navigate from search programmatically

### DIFF
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -143,7 +143,11 @@ function DocsLayout({ children, data, pageContext, ...props }) {
   } = useSiteMetadata();
   const { docsToc, framework } = pageContext;
   const [searchValue, setSearchValue] = useState('');
-  const { isSearchVisible } = useAlgoliaSearch({ framework, clearInput: () => setSearchValue('') });
+  const { isSearchVisible } = useAlgoliaSearch({
+    framework,
+    homepageUrl,
+    clearInput: () => setSearchValue(''),
+  });
 
   const addLinkWrappers = (items) =>
     items.map((item) => ({

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -143,7 +143,7 @@ function DocsLayout({ children, data, pageContext, ...props }) {
   } = useSiteMetadata();
   const { docsToc, framework } = pageContext;
   const [searchValue, setSearchValue] = useState('');
-  const { isSearchVisible } = useAlgoliaSearch({ framework });
+  const { isSearchVisible } = useAlgoliaSearch({ framework, clearInput: () => setSearchValue('') });
 
   const addLinkWrappers = (items) =>
     items.map((item) => ({

--- a/src/hooks/use-algolia-search.js
+++ b/src/hooks/use-algolia-search.js
@@ -6,7 +6,7 @@ export const SEARCH_INPUT_ID = 'algolia-search';
 const SEARCH_LIBRARY_SCRIPT_ID = 'algolia-search-library';
 const SEARCH_INIT_SCRIPT_ID = 'algolia-search-init';
 
-export default ({ framework, clearInput }) => {
+export default ({ framework, homepageUrl, clearInput }) => {
   const [isSearchVisible, setSearchVisible] = useState(!!process.env.GATSBY_ALGOLIA_API_KEY);
 
   useEffect(() => {
@@ -33,7 +33,7 @@ export default ({ framework, clearInput }) => {
             if (inputElement) inputElement.blur();
             // All search results have the full URL. In order to navigate within
             // the Gatsby app, we need to use a relative path.
-            navigate(suggestion.url.replace('https://storybook.js.org', ''));
+            navigate(suggestion.url.replace(homepageUrl, ''));
           },
         });
       } catch (err) {

--- a/src/hooks/use-algolia-search.js
+++ b/src/hooks/use-algolia-search.js
@@ -1,11 +1,12 @@
 /* eslint-env browser */
 import { useEffect, useState } from 'react';
+import { navigate } from 'gatsby';
 
 export const SEARCH_INPUT_ID = 'algolia-search';
 const SEARCH_LIBRARY_SCRIPT_ID = 'algolia-search-library';
 const SEARCH_INIT_SCRIPT_ID = 'algolia-search-init';
 
-export default ({ framework }) => {
+export default ({ framework, clearInput }) => {
   const [isSearchVisible, setSearchVisible] = useState(!!process.env.GATSBY_ALGOLIA_API_KEY);
 
   useEffect(() => {
@@ -23,6 +24,17 @@ export default ({ framework }) => {
           indexName: 'storybook-js',
           inputSelector: `#${SEARCH_INPUT_ID}`,
           algoliaOptions: { facetFilters: ['tags:docs', `framework:${framework}`] },
+          handleSelected: (input, event, suggestion, datasetNumber, context) => {
+            // input.setVal resets the search for Algolia
+            input.setVal('');
+            // clearInput updates the state of the element for React
+            clearInput();
+            const inputElement = document.querySelector(`#${SEARCH_INPUT_ID}`);
+            if (inputElement) inputElement.blur();
+            // All search results have the full URL. In order to navigate within
+            // the Gatsby app, we need to use a relative path.
+            navigate(suggestion.url.replace('https://storybook.js.org', ''));
+          },
         });
       } catch (err) {
         setSearchVisible(false);


### PR DESCRIPTION
The current search does a hard refresh of the gatsby app when you click a link, but we can override a few things to avoid that.

Caveat: this overrides command-click behavior (open in new tab) because the event that Algolia sends does not have the right info on it to differentiate between a normal click and command click. I am awaiting a response from them to see if there is a workaround.