### PR TITLE
Ensure search input extends the full width of available space

### DIFF
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -50,6 +50,12 @@ const StyledFrameworkSelector = styled(FrameworkSelector)`
   }
 `;
 
+const SearchInput = styled(Input)`
+  .algolia-autocomplete {
+    width: 100%;
+  }
+`;
+
 const SidebarControls = styled.div`
   display: flex;
   align-items: center;
@@ -62,7 +68,7 @@ const SidebarControls = styled.div`
   }
 
   /* input */
-  > *:nth-child(1) {
+  ${SearchInput} {
     @media (min-width: ${breakpoint * 1.333}px) {
       margin-right: 10px;
       flex: 1;
@@ -182,7 +188,7 @@ function DocsLayout({ children, data, pageContext, ...props }) {
               <>
                 <SidebarControls>
                   {isSearchVisible ? (
-                    <Input
+                    <SearchInput
                       id={SEARCH_INPUT_ID}
                       label="Search"
                       hideLabel


### PR DESCRIPTION
You'll have to go to the deploy preview because Storybook omits the search bar.

✅ The search box now looks like this:
![image](https://user-images.githubusercontent.com/263385/91226903-a9e4b180-e6f3-11ea-86a8-afba9d9a6383.png)


❌ Not this:
![image](https://user-images.githubusercontent.com/263385/91226881-a2bda380-e6f3-11ea-89e3-b5988a57935e.png)
