### PR TITLE
Hide remark header links on iframe layout

### DIFF
--- a/src/components/screens/ReleasesScreen/IframeReleasesScreen.js
+++ b/src/components/screens/ReleasesScreen/IframeReleasesScreen.js
@@ -21,6 +21,11 @@ const Content = styled.div`
 
   padding-top: 3rem;
   padding-bottom: 3rem;
+
+  .remark-header-link {
+    display: none;
+  }
+
   @media (min-width: ${breakpoint * 1.333}px) {
     padding-top: 4rem;
     padding-bottom: 4rem;


### PR DESCRIPTION
We have the "auto linked headers" in most of the frontpage (so you can click a heading & link to it), but they are not useful on the iframe screen because we don't really want people linking there.