### PR TITLE
Remove addon-contexts from AddonScreen

### DIFF
--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -229,11 +229,6 @@ export function PureAddonScreen({ ...props }) {
           desc="Navigate different versions of static Storybook builds to see how a component has changed over time."
           addonUrl="https://github.com/buildit/storybook-addon-versions"
         />
-        <AddonItem
-          title="Contexts"
-          desc="An elegant way to wrap your component stories and change their contextual environment directly and dynamically in Storybook UI!"
-          addonUrl="https://github.com/storybookjs/storybook/tree/master/addons/contexts"
-        />
 
         <Subheader>Test</Subheader>
         <AddonItem


### PR DESCRIPTION
Addon is deprecated and link 404s anyway