### PR TITLE
fix(gatsby-node): add polifyll for object.fromentries

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,6 +6,14 @@ const { createFilePath } = require(`gatsby-source-filesystem`);
 const { toc: docsToc } = require('./src/content/docs/toc');
 const buildPathWithFramework = require('./src/util/build-path-with-framework');
 
+// apply polifyll for Node < 12
+Object.fromEntries = Object.fromEntries || function (iterable) {
+  return [...iterable].reduce((obj, [key, val]) => {
+    obj[key] = val
+    return obj
+  }, {})
+}
+
 const githubDocsBaseUrl = 'https://github.com/storybookjs/storybook/tree/next';
 const addStateToToc = (items, pathPrefix = '/docs') =>
   items.map((item) => {
@@ -187,8 +195,8 @@ exports.createPages = ({ actions, graphql }) => {
                       tocItem,
                       ...(nextTocItem &&
                         nextTocItem.type === 'bullet-link' && {
-                          nextTocItem,
-                        }),
+                        nextTocItem,
+                      }),
                       isFirstTocItem: docsPagesSlugs.length === 0,
                     },
                   });


### PR DESCRIPTION
## Issue
`Object.fromEntries` is only supported in node 12, so anyone running this repo with another version will get the following error:

![image](https://user-images.githubusercontent.com/1671563/93022480-e700dd00-f5e9-11ea-9376-6b12713ecf8e.png)

## What I did
This PR adds a polyfill so that the code works fine regardless of node version.