### PR TITLE
Delete i18n from addons page

### DIFF
--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -252,11 +252,6 @@ export function PureAddonScreen({ ...props }) {
           addonUrl="https://github.com/tsuyoshiwada/storybook-chrome-screenshot"
         />
         <AddonItem
-          title="i18n"
-          desc="Toggle the locale and directly see the result in the preview. Intl library agnostic - can be used with any intl library. Supports automatic lrt/rtl change."
-          addonUrl="https://github.com/goooseman/storybook-addon-i18n"
-        />
-        <AddonItem
           title="Intl"
           desc="Toggle the locale and directly see the result in the preview."
           addonUrl="https://github.com/truffls/storybook-addon-intl"


### PR DESCRIPTION
The addon is deprected unless somebody takes it to maintain it.