### PR TITLE
Add storybook-addon-vscode-source

### DIFF
--- a/src/components/screens/AddonScreen/AddonScreen.js
+++ b/src/components/screens/AddonScreen/AddonScreen.js
@@ -309,6 +309,11 @@ export function PureAddonScreen({ ...props }) {
           desc="Display code preview with user selected knobs in various framework code."
           addonUrl="https://github.com/naver/storybook-addon-preview"
         />
+         <AddonItem
+          title="Open Component Code"
+          desc="Open the code of the component used in story directly in VS code (dev/local) and in Github repo (deployed/production)"
+          addonUrl="https://github.com/product-ride/storybook-addon-vscode-source"
+        />
 
         <Subheader>Data & State</Subheader>
         <AddonItem


### PR DESCRIPTION
Added storybook-addon-vscode-source to the addon list. It is a simple storybook addon that opens the source file of the component directly. In local/dev, it opens vs code and in prod deployment, it opens the file in GitHub repository.

![An animated gif of the addon](https://media.giphy.com/media/vUy3v9B9yWZh3Il3Dr/giphy.gif)