### PR TITLE
Chore: Fix for issue #171

### DIFF
--- a/src/content/releases/5.0.md
+++ b/src/content/releases/5.0.md
@@ -13,4 +13,4 @@ title: 'Storybook 5.0 - March 2019'
 
 ---
 
-5.0 contains hundreds more fixes, features, and tweaks. Browse the [changelogs](https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md) matching `5.0.0-alpha.*`, `5.0.0-beta.*`, and `5.0.0-rc.*` for the full list of changes. See [MIGRATION.md](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md) to upgrade from 4.x.
+5.0 contains hundreds more fixes, features, and tweaks. Browse the <a href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md">changelogs</a> matching `5.0.0-alpha.*`, `5.0.0-beta.*`, and `5.0.0-rc.*` for the full list of changes. See <a href="https://github.com/storybookjs/storybook/blob/next/MIGRATION.md">MIGRATION.md</a> to upgrade from 4.x.

--- a/src/content/releases/5.1.md
+++ b/src/content/releases/5.1.md
@@ -11,4 +11,4 @@ title: 'Storybook 5.1 - June 2019'
 
 ---
 
-5.1 contains hundreds more fixes, features, and tweaks. Browse the [changelogs](https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md) matching `5.1.0-alpha.*`, `5.1.0-beta.*`, and `5.1.0-rc.*` for the full list of changes. See [MIGRATION.md](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md) to ugprade from 5.0 or earlier.
+5.1 contains hundreds more fixes, features, and tweaks. Browse the <a href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md">changelogs</a> matching `5.1.0-alpha.*`, `5.1.0-beta.*`, and `5.1.0-rc.*` for the full list of changes. See <a href="https://github.com/storybookjs/storybook/blob/next/MIGRATION.md">MIGRATION.md</a> to upgrade from 5.0 or earlier.

--- a/src/content/releases/5.2.md
+++ b/src/content/releases/5.2.md
@@ -10,4 +10,4 @@ title: 'Storybook 5.2 - September 2019'
 
 ---
 
-5.2 contains hundreds more fixes, features, and tweaks. Browse the [changelogs](https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md) matching `5.2.0-alpha.*`, `5.2.0-beta.*`, and `5.2.0-rc.*` for the full list of changes. See [MIGRATION.md](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md) to upgrade from 5.0 or earlier.
+5.2 contains hundreds more fixes, features, and tweaks. Browse the <a href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md">changelogs</a> matching `5.2.0-alpha.*`, `5.2.0-beta.*`, and `5.2.0-rc.*` for the full list of changes. See <a href="https://github.com/storybookjs/storybook/blob/next/MIGRATION.md">MIGRATION.md</a> to upgrade from 5.0 or earlier.

--- a/src/content/releases/5.3.md
+++ b/src/content/releases/5.3.md
@@ -11,4 +11,4 @@ title: 'Storybook 5.3 - January 2020'
 
 ---
 
-5.3 contains hundreds more fixes, features, and tweaks. Browse the [changelogs](https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md) matching `5.3.0-alpha.*`, `5.3.0-beta.*`, and `5.3.0-rc.*` for the full list of changes. See [MIGRATION.md](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md) to upgrade from 5.0 or earlier.
+5.3 contains hundreds more fixes, features, and tweaks. Browse the <a href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md">changelogs</a> matching `5.3.0-alpha.*`, `5.3.0-beta.*`, and `5.3.0-rc.*` for the full list of changes. See <a href="https://github.com/storybookjs/storybook/blob/next/MIGRATION.md">MIGRATION.md</a> to upgrade from 5.0 or earlier.

--- a/src/content/releases/6.0.md
+++ b/src/content/releases/6.0.md
@@ -12,4 +12,4 @@ title: 'Storybook 6.0 - August 2020'
 
 ---
 
-6.0 contains hundreds more fixes, features, and tweaks. Browse the [changelogs](https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md) matching `6.0.0-alpha.*`, `6.0.0-beta.*`, and `6.0.0-rc.*` for the full list of changes. See [Storybook 6 migration guide](https://medium.com/storybookjs/storybook-6-migration-guide-200346241bb5) to upgrade from `5.3` or earlier.
+6.0 contains hundreds more fixes, features, and tweaks. Browse the <a href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md">changelogs</a> matching `6.0.0-alpha.*`, `6.0.0-beta.*`, and `6.0.0-rc.*` for the full list of changes. See [Storybook 6 migration guide](https://medium.com/storybookjs/storybook-6-migration-guide-200346241bb5) to upgrade from `5.3` or earlier.

--- a/src/content/releases/6.1.md
+++ b/src/content/releases/6.1.md
@@ -9,4 +9,4 @@ prerelease: true
 
 ---
 
-6.1 contains hundreds more fixes, features, and tweaks. Browse the [changelogs](https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md) matching `6.1.0-alpha.*`, `6.1.0-beta.*`, and `6.1.0-rc.*` for the full list of changes. See [Storybook 6 migration guide](https://medium.com/storybookjs/storybook-6-migration-guide-200346241bb5) to upgrade from `5.3` or earlier.
+6.1 contains hundreds more fixes, features, and tweaks. Browse the <a href="https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md">changelogs</a> matching `6.1.0-alpha.*`, `6.1.0-beta.*`, and `6.1.0-rc.*` for the full list of changes. See [Storybook 6 migration guide](https://medium.com/storybookjs/storybook-6-migration-guide-200346241bb5) to upgrade from `5.3` or earlier.


### PR DESCRIPTION
With this pull request issue #171 is addressed and can be closed.

What was done:
- Changed the links from markdown to `<a>` tags, preventing 404 errors when the reader clicks the links.

The culprit for this issue is `gatsby-remark-link-rewrite, it works in our favor for the bulk extent of the documentation but for cases like this it will work against us, generating invalid urls, as the ones currently live in the releases page. By changing them to ´<a>´ tags, the plugin will bypass the links and will ignore them allowing them to be correct. 

Feel free to provide feedback