### PR TITLE
Add LinkWrapper for Docs, Release in nav

### DIFF
--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -111,7 +111,7 @@ export default function Header({ ...props }) {
       links={
         <>
           <NavItem showDesktop>
-            <NavLink tertiary href={docs} isGatsby>
+            <NavLink tertiary href={docs} isGatsby LinkWrapper={LinkWrapper}>
               Docs
             </NavLink>
           </NavItem>
@@ -121,7 +121,7 @@ export default function Header({ ...props }) {
             </NavLink>
           </NavItem>
           <NavItem showDesktop>
-            <NavLink tertiary href={releases} isGatsby>
+            <NavLink tertiary href={releases} isGatsby LinkWrapper={LinkWrapper}>
               Releases
             </NavLink>
           </NavItem>


### PR DESCRIPTION
I noticed that the Docs & Releases links in the nav were reloading the page. Kinda hard to keep track of all these LinkWrappers, but this should fix it for the time being.