### PR TITLE
Remove addons redirect rule

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -22,7 +22,6 @@
 /docs/basics/guide-riot /docs/guides/guide-riot 301
 /docs/basics/guide-html /docs/guides/guide-html 301
 
-/addons/* /docs/addons/:splat 301
 /basics/* /docs/basics/:splat 301
 /configurations/* /docs/configurations/:splat 301
 /examples/* /docs/examples/:splat 301


### PR DESCRIPTION
Discovered that this rule is leading to a lot of 404s in our SEO report. I don't think we need this anymore. It was probably redirecting addon doc pages. 