### PR TITLE
Addons: Fix link to NPM page on details page

### DIFF
--- a/src/util/create-addons-pages.js
+++ b/src/util/create-addons-pages.js
@@ -96,6 +96,7 @@ function fetchAddonsDetailPages(createPage, graphql, skip = 0) {
               publishedAt
               repositoryUrl
               homepageUrl
+              npmUrl
             }
           }
         }`


### PR DESCRIPTION
Issue: N/A (thanks @pocka for reporting!)

### What I did

Addon details pages are linking to themselves. Fixed the query to link to NPM page

### How to test

Detail page before (live site) & after (deploy preview)