### PR TITLE
convert readme links to absolute

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,14 @@
     "react-helmet": "^5.2.1",
     "react-lazyload": "^2.6.5",
     "recompose": "^0.30.0",
+    "rehype": "^11.0.0",
+    "rehype-stringify": "^8.0.0",
+    "rehype-urls": "^1.1.1",
     "remark-html": "^13.0.1",
     "request": "^2.88.2",
     "semver": "^7.3.2",
     "styled-components": "^4.4.1",
+    "unist-util-visit": "^2.0.3",
     "validatorjs": "^3.15.1"
   },
   "keywords": [

--- a/src/util/absolute-links.js
+++ b/src/util/absolute-links.js
@@ -1,0 +1,52 @@
+const { resolve, format } = require('url');
+const rehype = require('rehype');
+const rehypeUrls = require('rehype-urls');
+const rehypeStringify = require('rehype-stringify');
+const visit = require('unist-util-visit');
+
+function absoluteLink(link, { base } = {}) {
+  if (link.startsWith('#')) {
+    return link;
+  }
+  return resolve(base, link);
+}
+
+function absoluteLinksHtml(html, opts) {
+  const buf = rehype()
+    .use(rehypeUrls, (url) => {
+      return absoluteLink(format(url), opts);
+    })
+    .use(rehypeStringify, { closeSelfClosing: true })
+    .processSync(html);
+
+  return String(buf).replace('<html><head></head><body>', '').replace('</body></html>', '\n');
+}
+
+module.exports = function absoluteLinks(opts) {
+  return transform;
+
+  function transform(tree) {
+    visit(tree, ['link', 'html'], visitor);
+
+    function visitor(node) {
+      // console.log('visit', node);
+
+      if (!node) return;
+
+      switch (node.type) {
+        case 'link': {
+          // eslint-disable-next-line
+          node.url = absoluteLink(node.url, opts);
+          return;
+        }
+        case 'html': {
+          // eslint-disable-next-line
+          node.value = absoluteLinksHtml(node.value, opts);
+          return;
+        }
+        default:
+          throw new Error(`Unexpected: ${node.type}`);
+      }
+    }
+  }
+};

--- a/src/util/create-addons-pages.js
+++ b/src/util/create-addons-pages.js
@@ -3,8 +3,7 @@ const path = require('path');
 const remark = require('remark');
 const remarkHTML = require('remark-html');
 const buildTagLinks = require('./build-tag-links');
-
-const processor = remark().use(remarkHTML);
+const absoluteLinks = require('./absolute-links');
 
 const addonDetail = `
   id: name
@@ -121,6 +120,12 @@ function fetchAddonsDetailPages(createPage, graphql, skip = 0) {
 
 function createAddonsDetailPages(createPage, addonPages) {
   addonPages.forEach((addon) => {
+    const processor = remark()
+      .use(absoluteLinks, {
+        base: `${addon.repositoryUrl}/`,
+      })
+      .use(remarkHTML);
+
     createPage({
       path: `/addons/${addon.name}`,
       component: path.resolve(`./src/components/screens/AddonsDetailScreen/AddonsDetailScreen.js`),

--- a/yarn.lock
+++ b/yarn.lock
@@ -12488,6 +12488,11 @@ hast-util-from-parse5@^6.0.0:
     vfile "^4.0.0"
     web-namespaces "^1.0.0"
 
+hast-util-has-property@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz#9f137565fad6082524b382c1e7d7d33ca5059f36"
+  integrity sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==
+
 hast-util-is-element@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz#3b3ed5159a2707c6137b48637fbfe068e175a425"
@@ -12535,7 +12540,7 @@ hast-util-sanitize@^3.0.0:
   dependencies:
     xtend "^4.0.0"
 
-hast-util-to-html@^7.0.0:
+hast-util-to-html@^7.0.0, hast-util-to-html@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-7.1.2.tgz#db677f0ee483658cea0eecc9dec30aba42b67111"
   integrity sha512-pu73bvORzdF6XZgwl9eID/0RjBb/jtRfoGRRSykpR1+o9rCdiAHpgkSukZsQBRlIqMg6ylAcd7F0F7myJUb09Q==
@@ -13392,7 +13397,7 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
-is-arrayish@^0.3.1:
+is-arrayish@^0.3.1, is-arrayish@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
@@ -19249,6 +19254,39 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
+rehype-parse@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-7.0.1.tgz#58900f6702b56767814afc2a9efa2d42b1c90c57"
+  integrity sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==
+  dependencies:
+    hast-util-from-parse5 "^6.0.0"
+    parse5 "^6.0.0"
+
+rehype-stringify@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-8.0.0.tgz#9b6afb599bcf3165f10f93fc8548f9a03d2ec2ba"
+  integrity sha512-VkIs18G0pj2xklyllrPSvdShAV36Ff3yE5PUO9u36f6+2qJFnn22Z5gKwBOwgXviux4UC7K+/j13AnZfPICi/g==
+  dependencies:
+    hast-util-to-html "^7.1.1"
+
+rehype-urls@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rehype-urls/-/rehype-urls-1.1.1.tgz#4a0aed7cc8740ace03a5a323dd50596d272f9fdf"
+  integrity sha512-ct9Kb/nAL6oe/O5fDc0xjiqm8Z9xgXdorOdDhZAWx7awucyiuYXU7Dax+23Gu24nnGwtdaCW6zslKAYzlEW1lw==
+  dependencies:
+    hast-util-has-property "^1.0.2"
+    stdopt "^2.0.0"
+    unist-util-visit "^1.4.0"
+
+rehype@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/rehype/-/rehype-11.0.0.tgz#d81729e65f4ac2b26f5de0b6bafc257eb0780e1f"
+  integrity sha512-qXqRqiCFJD5CJ61CSJuNImTFrm3zVkOU9XywHDwrUuvWN74MWt72KJ67c5CM5x8g0vGcOkRVCrYj85vqkmHulQ==
+  dependencies:
+    rehype-parse "^7.0.0"
+    rehype-stringify "^8.0.0"
+    unified "^9.0.0"
+
 relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
@@ -20959,6 +20997,13 @@ static-site-generator-webpack-plugin@^3.4.2:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+stdopt@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/stdopt/-/stdopt-2.2.0.tgz#2ecadb59b9f13babf4b2b9ca9a494d85009ea142"
+  integrity sha512-D/p41NgXOkcj1SeGhfXOwv9z1K6EV3sjAUY5aeepVbgEHv7DpKWLTjhjScyzMWAQCAgUQys1mjH0eArm4cjRGw==
+  dependencies:
+    is-arrayish "^0.3.2"
+
 stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -22466,7 +22511,7 @@ unist-util-visit@2.0.2, unist-util-visit@^2.0.0, unist-util-visit@^2.0.2:
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
 
-unist-util-visit@2.0.3:
+unist-util-visit@2.0.3, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
@@ -22475,7 +22520,7 @@ unist-util-visit@2.0.3:
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
 
-unist-util-visit@^1.1.0, unist-util-visit@^1.3.0, unist-util-visit@^1.4.1:
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0, unist-util-visit@^1.4.0, unist-util-visit@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==


### PR DESCRIPTION
@shilman this at least takes you to the correct repo but, fails for most scenarios since we can't account for branch and/or release names. I'm not sure how we can get that info. 

**Update:** this is the same strategy used by NPM. It's quite hard to guess the correct url since it can be a raw user content url or reference a branch or a release. 