### PR TITLE
link-monorepo-docs.sh should not recursively delete if soft link already exists

### DIFF
--- a/scripts/link-monorepo-docs.sh
+++ b/scripts/link-monorepo-docs.sh
@@ -17,9 +17,15 @@ fi
 TARGET_DIR="$MONOREPO_PATH/$REPO_SUBDIR"
 
 if [ -d "$TARGET_DIR" ]; then
-  rm -rf "$REPO_DIRNAME"
+  if [ ! -L $REPO_DIRNAME ]; then
+    echo "Deleting default docs"
+    rm -rf "$REPO_DIRNAME"
+  else
+    # remove softlink
+    rm "$REPO_DIRNAME"
+  fi
   ln -s "$RELATIVE_DIRNAME/$TARGET_DIR" "$REPO_DIRNAME"
-else 
+else
   echo "Couldn't find monorepo docs at '$TARGET_DIR'"
   exit 1;
 fi


### PR DESCRIPTION
Re-running `yarn link-monorepo-docs` recursively deletes the developer's local edits.

I changed the script to only delete the content of `src/content/docs` if it is not a soft link.
If the softlink to `docs` already exists only the link is deleted.