### PR TITLE
fail build if tagPages in missing in response

### DIFF
--- a/src/util/create-addons-pages.js
+++ b/src/util/create-addons-pages.js
@@ -171,7 +171,7 @@ function fetchTagPages(createPage, graphql, skip = 0) {
           addons: { tagPages },
         },
       }) => {
-        if (tagPages && tagPages.length > 0) {
+        if (tagPages.length > 0) {
           createTagPages(createPage, tagPages);
           return fetchTagPages(createPage, graphql, skip + tagPages.length);
         }


### PR DESCRIPTION
@shilman added a stricter check. I'm noticing that the builds do end up failing quite regularly. Even before we hit the tags request. Is there something we can do to up the back-end resources? 