### PR TITLE
add trailing slash to canonical urls on docs pages

### DIFF
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -187,7 +187,7 @@ function DocsLayout({ children, data, pageContext, ...props }) {
     <>
       <GlobalStyle />
       <Helmet>
-        <link rel="canonical" href={`${homepageUrl}${buildPathWithFramework(slug, 'react')}`} />
+        <link rel="canonical" href={`${homepageUrl}${buildPathWithFramework(slug, 'react')}/`} />
         <meta name="docsearch:framework" content={framework} />
         <link
           rel="stylesheet"


### PR DESCRIPTION
Netlify adds redirects for trailing slashes. Unfortunately we can't disable this. Not really an issue for us except for canonical urls. For example:

```
<link data-react-helmet="true" rel="canonical" href="https://storybook.js.org/docs/react/get-started/introduction"/>
```

The url referenced above has a 301 redirect to `https://storybook.js.org/docs/react/get-started/introduction/`. 

I added a trailing slash to canonical urls to avoid this.