### PR TITLE
Add trailing slash to links in sitemap

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -148,6 +148,21 @@ module.exports = {
         component: require.resolve('./src/components/layout/PageLayout'),
       },
     },
-    'gatsby-plugin-sitemap',
+    {
+      resolve: `gatsby-plugin-sitemap`,
+      options: {
+        serialize: ({ site, allSitePage }) => {
+          const allPages = allSitePage.edges.map((edge) => edge.node);
+
+          return allPages.map((page) => {
+            return {
+              url: `${site.siteMetadata.siteUrl}${page.path}/`,
+              changefreq: `daily`,
+              priority: 0.7,
+            };
+          });
+        },
+      },
+    },
   ],
 };


### PR DESCRIPTION
Related to the SEO issue. Add trailing slash to links in sitemap so that it's not pointing to a redirect. 