### PR TITLE
Fix <details> arrow regression in latest Chromium

### DIFF
--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -313,7 +313,7 @@ export const mdFormatting = css`
   }
 
   details > summary {
-    display: inline-block;
+    display: list-item;
     cursor: pointer;
     color: ${darken(0.2, color.secondary)};
   }


### PR DESCRIPTION
In the latest Chrome, the `<details>` arrow has gone missing. Adding this style fixes it.

Confirm the fix by going to the deploy preview > docs > Get Started > Install and checking if the arrow is visible. [Go HERE](https://deploy-preview-241--storybook-frontpage.netlify.app/docs/react/get-started/install)

![image](https://user-images.githubusercontent.com/263385/111538187-c5241680-8742-11eb-825b-6e9e0d0aaf79.png)
