### PR TITLE
fix typo : npx -> npm

### DIFF
--- a/src/components/layout/addons/AddonItemDetail.js
+++ b/src/components/layout/addons/AddonItemDetail.js
@@ -222,7 +222,7 @@ export const AddonItemDetail = ({
           <span>{isLoading ? 'loading description of addon' : description}</span>
         </Description>
         <Instructions status={status}>
-          <ClipboardCode code={`npx install ${name}`} />
+          <ClipboardCode code={`npm install ${name}`} />
           {publishedAt && (
             <Update>
               <Link href={npmUrl} target="_blank" rel="noopener nofollow noreferrer">


### PR DESCRIPTION
Can't install addons with the `npx` command 😢 
I think it's correct to use the `npm` command to install the addons.