### PR TITLE
Add option to skip addon pages build for dev and when running chromatic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,6 @@ jobs:
 
       - run: yarn lint
 
-      - run: GATSBY_CPU_COUNT=1 yarn build
+      - run: GATSBY_CPU_COUNT=1 GATSBY_SKIP_ADDON_PAGES=true yarn build
       - run: yarn build-storybook
       - run: yarn chromatic --storybook-build-dir storybook-static --exit-zero-on-changes

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The Storybook for Storybook contains every UI component. The UI is built followi
 
 Gatsby is used for basic routing and static site generation.
 
-1. yarn start
+1. `yarn start` to run the entire site
+
+2. `yarn start:skip-addons` to skip building the addon catalog
 
 #### Docs content
 
@@ -62,7 +64,7 @@ Search within the docs is powered by [DocSearch](https://docsearch.algolia.com/)
 
 `GATSBY_ALGOLIA_API_KEY`
 
-In development and with local production builds, that environment variable can be configured with `.env` files as explaned [here](https://www.gatsbyjs.com/docs/environment-variables/#client-side-javascript). The `GATSBY_` prefix ensures that the variable is available in client-side code. 
+In development and with local production builds, that environment variable can be configured with `.env` files as explaned [here](https://www.gatsbyjs.com/docs/environment-variables/#client-side-javascript). The `GATSBY_` prefix ensures that the variable is available in client-side code.
 
 How to setup on your machine:
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -231,7 +231,11 @@ exports.createPages = ({ actions, graphql }) => {
           }
         }
       )
-      .then(() => createAddonsPages({ actions, graphql }))
+      .then(() => {
+        return process.env.GATSBY_SKIP_ADDON_PAGES
+          ? Promise.resolve()
+          : createAddonsPages({ actions, graphql });
+      })
       .then(() => {
         resolve();
       });

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "develop": "gatsby develop",
     "clean": "gatsby clean",
     "start": "npm run develop",
+    "start:skip-addons": "GATSBY_SKIP_ADDON_PAGES=true npm run develop",
     "format": "prettier --write \"src/**/*.js\"",
     "lint": "eslint src .storybook --ext .js,.jsx,.json,.html,.ts,.tsx,.mjs --report-unused-disable-directives",
     "test": "jest",

--- a/src/util/create-addons-pages.js
+++ b/src/util/create-addons-pages.js
@@ -5,6 +5,8 @@ const remarkHTML = require('remark-html');
 const buildTagLinks = require('./build-tag-links');
 const absoluteLinks = require('./absolute-links');
 
+const DELAY = 200;
+
 const addonDetail = `
   id: name
   name
@@ -71,7 +73,7 @@ function fetchCategoryPages(createPage, graphql) {
 
 function fetchAddonsDetailPages(createPage, graphql, skip = 0) {
   return new Promise((resolve) => {
-    setTimeout(resolve, 100);
+    setTimeout(resolve, DELAY);
   })
     .then(() =>
       graphql(
@@ -140,7 +142,7 @@ function createAddonsDetailPages(createPage, addonPages) {
 
 function fetchTagPages(createPage, graphql, skip = 0) {
   return new Promise((resolve) => {
-    setTimeout(resolve, 100);
+    setTimeout(resolve, DELAY);
   })
     .then(() =>
       graphql(


### PR DESCRIPTION
Added a `GATSBY_SKIP_ADDON_PAGES` flag. It's used in:

1. `yarn start:skip-addons` to allow you to run the site without having to build all addon pages
2. CircleCI to run a Gatsby build which provides data for the Storybook build which in turn is used for Chromatic. 

All in all, it should speed up the CI checks and only the netlify build should query for actual addon data. That way we aren't hammering the back-end. 