### PR TITLE
Chore: Changes to the community addons

### DIFF
--- a/src/components/screens/DocsScreen/FrameworkSupportTable.tsx
+++ b/src/components/screens/DocsScreen/FrameworkSupportTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link as GatsbyLink } from 'gatsby';
 import stylizeFramework from '../../../util/stylize-framework';
-import { fetchCommunityAddons } from '../../../util/community-addons';
+import { communityAddons } from '../../../util/community-addons';
 
 export function frameworkSupportsFeature(framework, { supported, unsupported }) {
   return (
@@ -21,8 +21,7 @@ export const FrameworkSupportTable = ({ currentFramework, frameworks, featureGro
       return `${monorepoUrlBase}/${repoPath}`;
     }
     // Default is it is an addon (moved into the community or actively maintained)
-    const communityAddon= fetchCommunityAddons(name);
-    return communityAddon || `${monorepoUrlBase}/addons/${name}`;
+    return communityAddons[name] || `${monorepoUrlBase}/addons/${name}`;
   }
 
   return (

--- a/src/components/screens/DocsScreen/FrameworkSupportTable.tsx
+++ b/src/components/screens/DocsScreen/FrameworkSupportTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link as GatsbyLink } from 'gatsby';
 import stylizeFramework from '../../../util/stylize-framework';
+import { fetchCommunityAddons } from '../../../util/community-addons';
 
 export function frameworkSupportsFeature(framework, { supported, unsupported }) {
   return (
@@ -19,8 +20,9 @@ export const FrameworkSupportTable = ({ currentFramework, frameworks, featureGro
     if (repoPath) {
       return `${monorepoUrlBase}/${repoPath}`;
     }
-    // Default is it is an addon
-    return `${monorepoUrlBase}/addons/${name}`;
+    // Default is it is an addon (moved into the community or actively maintained)
+    const communityAddon= fetchCommunityAddons(name);
+    return communityAddon || `${monorepoUrlBase}/addons/${name}`;
   }
 
   return (

--- a/src/util/community-addons.js
+++ b/src/util/community-addons.js
@@ -1,42 +1,10 @@
-const communityAddons = [
-  {
-    name: 'design-assets',
-    repository: 'https://github.com/storybookjs/addon-design-assets',
-  },
-  {
-    name: 'events',
-    repository: 'https://github.com/storybookjs/addon-events',
-  },
-  {
-    name: 'cssresources',
-    repository: 'https://github.com/storybookjs/addon-cssresources',
-  },
-  {
-    name: 'graphql',
-    repository: 'https://github.com/storybookjs/addon-graphql',
-  },
-  {
-    name: 'queryparams',
-    repository: 'https://github.com/storybookjs/addon-queryparams',
-  },
-  {
-    name: 'google-analytics',
-    repository: 'https://github.com/storybookjs/addon-google-analytics',
-  },
-  {
-    name: 'knobs',
-    repository: 'https://github.com/storybookjs/addon-knobs',
-  },
-];
-
-/**
- * Simple function to filter out the addons that are currently not maintained by Storybook
- * @param {string} name name of the community addon
- */
-export const fetchCommunityAddons = (name) => {
-  const addon = communityAddons.find((addonName) => addonName.name === name);
-  if (addon) {
-    return addon.repository;
-  }
-  return null;
+// List of community addons that were moved out of the monorepo to their own repositories
+export const communityAddons = {
+  'design-assets': 'https://github.com/storybookjs/addon-design-assets',
+  events: 'https://github.com/storybookjs/addon-events',
+  cssresources: 'https://github.com/storybookjs/addon-cssresources',
+  graphql: 'https://github.com/storybookjs/addon-graphql',
+  queryparams: 'https://github.com/storybookjs/addon-queryparams',
+  'google-analytics': 'https://github.com/storybookjs/addon-google-analytics',
+  knobs: 'https://github.com/storybookjs/addon-knobs',
 };

--- a/src/util/community-addons.js
+++ b/src/util/community-addons.js
@@ -1,0 +1,42 @@
+const communityAddons = [
+  {
+    name: 'design-assets',
+    repository: 'https://github.com/storybookjs/addon-design-assets',
+  },
+  {
+    name: 'events',
+    repository: 'https://github.com/storybookjs/addon-events',
+  },
+  {
+    name: 'cssresources',
+    repository: 'https://github.com/storybookjs/addon-cssresources',
+  },
+  {
+    name: 'graphql',
+    repository: 'https://github.com/storybookjs/addon-graphql',
+  },
+  {
+    name: 'queryparams',
+    repository: 'https://github.com/storybookjs/addon-queryparams',
+  },
+  {
+    name: 'google-analytics',
+    repository: 'https://github.com/storybookjs/addon-google-analytics',
+  },
+  {
+    name: 'knobs',
+    repository: 'https://github.com/storybookjs/addon-knobs',
+  },
+];
+
+/**
+ * Simple function to filter out the addons that are currently not maintained by Storybook
+ * @param {string} name name of the community addon
+ */
+export const fetchCommunityAddons = (name) => {
+  const addon = communityAddons.find((addonName) => addonName.name === name);
+  if (addon) {
+    return addon.repository;
+  }
+  return null;
+};


### PR DESCRIPTION
With this pull request, the framework support table component is updated to properly show the URLs related to the community addons that were moved out of the monorepo:
-design-assets
- events
- cssresources
- graphql
- queryparams
- google-analytics
- knobs 

Allowing the documentation in [here](https://storybook.js.org/docs/react/api/frameworks-feature-support) to show the correct location of said addons.

What was done:
- Created a simple module that we can build on top of for future addons that might be pushed out of the repo.
- Updated the Component to reflect the changes above.


Originally, I thought about moving this information into the Storybook docs toc.js file, but that would lead to include one additional pull request for that specific portion of information and one here to properly handle it. If we can solve it with only one, why not.

Feel free to provide feedback
