### PR TITLE
Optimize SEO for docs

### DIFF
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -183,11 +183,18 @@ function DocsLayout({ children, data, pageContext, ...props }) {
     as: 'span',
   };
 
+  // The React specific docs are treated as canonical except for the
+  // docs home page for all other frameworks.
+  const canonicalFramework = slug === '/docs/get-started/introduction' ? framework : 'react';
+
   return (
     <>
       <GlobalStyle />
       <Helmet>
-        <link rel="canonical" href={`${homepageUrl}${buildPathWithFramework(slug, framework)}/`} />
+        <link
+          rel="canonical"
+          href={`${homepageUrl}${buildPathWithFramework(slug, canonicalFramework)}/`}
+        />
         <meta name="docsearch:framework" content={framework} />
         <link
           rel="stylesheet"


### PR DESCRIPTION
### What I did

1. No index the documentation for all frameworks except React
2. Index the documentation homepage for all frameworks (eg: so storybook vue” takes you to that page)


@shilman at one point we were generating the React URL as the canonical  link for all docs pages. Like so:

```
<link rel="canonical" href={`${homepageUrl}${buildPathWithFramework(slug, 'react')}/`} />
```

I think the `robots.txt` approach is cleaner since that won't tag the framework specific documentation homepage with the React canonical url.
