### PR TITLE
Tweak homepage headline to highlight "component driven UIs"

### DIFF
--- a/src/components/screens/IndexScreen/Hero.js
+++ b/src/components/screens/IndexScreen/Hero.js
@@ -373,7 +373,7 @@ export default function Hero({ startOpen, ...props }) {
     <AspectRatio ratio={0.5625}>
       <ModalVideoWrapper>
         <ModalVideo
-          title="Chromatic intro video"
+          title="Storybook intro video"
           width="560"
           height="315"
           src="https://www.youtube.com/embed/p-LFh5Y89eM?autoplay=1&rel=0&amp;showinfo=0"
@@ -389,7 +389,7 @@ export default function Hero({ startOpen, ...props }) {
   return (
     <Wrapper {...props}>
       <Pitch>
-        <Title>Build bulletproof UI components faster</Title>
+        <Title>Build component driven UIs faster</Title>
         <Subtitle>
           Storybook is an open source tool for building UI components and pages in isolation. It
           streamlines UI development, testing, and documentation.

--- a/src/components/screens/IndexScreen/Hero.js
+++ b/src/components/screens/IndexScreen/Hero.js
@@ -104,7 +104,7 @@ const PitchActions = styled.div`
 
 const Pitch = styled.div`
   text-align: center;
-  max-width: 600px;
+  max-width: 640px;
   margin: 0 auto;
   margin-bottom: 3rem;
   @media (min-width: ${breakpoint * 2}px) {


### PR DESCRIPTION
**Why** 
Be more specific about what Storybook is actually intended for. It doesn't just help you build "bulletproof UI components" but with the entire process of building UIs with components.