### PR TITLE
Versioned docs fixes

### DIFF
--- a/.storybook/useSiteMetadata.js
+++ b/.storybook/useSiteMetadata.js
@@ -1,3 +1,4 @@
 const siteMetadata = require('../site-metadata.js');
+const versionData = require('../src/util/version-data.js');
 
-export default () => siteMetadata;
+export default () => ({ ...siteMetadata, ...versionData });

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,21 +2,25 @@ const path = require('path');
 const { global } = require('@storybook/design-system');
 const siteMetadata = require('./site-metadata');
 const getReleaseBranchUrl = require('./src/util/get-release-branch-url');
+const versionData = require('./src/util/version-data');
 
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
 });
 
-const { isLatest, versionString } = siteMetadata;
-
 module.exports = {
-  siteMetadata,
+  siteMetadata: {
+    ...siteMetadata,
+    ...versionData,
+  },
   flags: {
     PRESERVE_WEBPACK_CACHE: true,
     FAST_DEV: true,
     QUERY_ON_DEMAND: true,
   },
-  ...(!isLatest ? { assetPrefix: getReleaseBranchUrl(versionString) } : undefined),
+  ...(!versionData.isLatest
+    ? { assetPrefix: getReleaseBranchUrl(versionData.versionString) }
+    : undefined),
   plugins: [
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-typescript',
@@ -138,14 +142,14 @@ module.exports = {
           '/*': [
             'X-XSS-Protection: 1; mode=block',
             'X-Content-Type-Options: nosniff',
-            ...(!isLatest ? ['Access-Control-Allow-Origin: *'] : []),
+            ...(!versionData.isLatest ? ['Access-Control-Allow-Origin: *'] : []),
           ],
           '/versions.json': [
             'Access-Control-Allow-Origin: *',
             'Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept',
           ],
-          ...(!isLatest && {
-            [`/docs/${versionString}/*`]: ['X-Robots-Tag: noindex'],
+          ...(!versionData.isLatest && {
+            [`/docs/${versionData.versionString}/*`]: ['X-Robots-Tag: noindex'],
           }),
         },
         // Do not use the default security headers. Use those we have defined above.
@@ -159,7 +163,7 @@ module.exports = {
         component: require.resolve('./src/components/layout/PageLayout'),
       },
     },
-    ...(isLatest
+    ...(versionData.isLatest
       ? [
           {
             resolve: `gatsby-plugin-sitemap`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,12 +3,17 @@ const path = require('path');
 
 const { createFilePath } = require(`gatsby-source-filesystem`);
 
-const { versionString, latestVersion, latestVersionString, isLatest } = require('./site-metadata');
 const { toc: docsToc } = require('./src/content/docs/toc');
 const addStateToToc = require('./src/util/add-state-to-toc');
 const buildPathWithFramework = require('./src/util/build-path-with-framework');
 const createAddonsPages = require('./src/util/create-addons-pages');
 const getReleaseBranchUrl = require('./src/util/get-release-branch-url');
+const {
+  versionString,
+  latestVersion,
+  latestVersionString,
+  isLatest,
+} = require('./src/util/version-data');
 
 const VERSION_PARTS_REGEX = /^(\d+\.\d+)(?:\.\d+)?-?(\w+)?(?:\.\d+$)?/;
 
@@ -259,7 +264,7 @@ exports.createPages = ({ actions, graphql }) => {
 
           if (firstDocsPageSlug) {
             createRedirect({
-              fromPath: `/docs/${isLatest ? '' : versionString}`,
+              fromPath: `/docs/${isLatest ? '' : `${versionString}/`}`,
               isPermanent: false,
               redirectInBrowser: true,
               toPath: buildPathWithFramework(firstDocsPageSlug, frameworks[0]),

--- a/site-metadata.js
+++ b/site-metadata.js
@@ -3,14 +3,6 @@ const {
   communityFrameworks,
   featureGroups,
 } = require('./src/content/docs/frameworks');
-const { version: versionFull } = require('./src/generated/versions/current/package.json');
-const { version: latestVersionFull } = require('./src/generated/versions/latest/package.json');
-
-const VERSION_PARTS_REGEX = /^(\d+\.\d+)(?:\.\d+)?-?(\w+)?(?:\.\d+$)?/;
-const [, versionString] = versionFull.match(VERSION_PARTS_REGEX);
-const version = parseFloat(versionString);
-const [, latestVersionString] = latestVersionFull.match(VERSION_PARTS_REGEX);
-const latestVersion = parseFloat(latestVersionString);
 
 const isDeployPreview = process.env.CONTEXT === 'deploy-preview';
 const homepageUrl = isDeployPreview ? process.env.DEPLOY_PRIME_URL : 'https://storybook.js.org';
@@ -26,11 +18,6 @@ const siteMetadata = {
   ogImageAddons: '/images/social/og-addons.png',
   siteUrl: homepageUrl, // Used for gatsby-plugin-sitemap
   googleSiteVerification: '_OxxMv1o0aRcxPfieLW0BRsMxxIzkpA9Vv6O0AB5xg0',
-  version,
-  versionString,
-  latestVersion,
-  latestVersionString,
-  isLatest: version === latestVersion,
   contributorCount: 1290,
   coreFrameworks,
   communityFrameworks,

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -160,6 +160,7 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext, ...props })
     urls: { homepageUrl },
     version,
     latestVersion,
+    latestVersionString,
     isLatest,
   } = useSiteMetadata();
   const { docsToc, framework, fullPath, slug, versions } = pageContext;
@@ -277,6 +278,7 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext, ...props })
               framework={framework}
               version={version}
               latestVersion={latestVersion}
+              latestVersionString={latestVersionString}
               versions={versions}
               slug={slug}
             />

--- a/src/components/screens/DocsScreen/FrameworkSelector.tsx
+++ b/src/components/screens/DocsScreen/FrameworkSelector.tsx
@@ -73,7 +73,7 @@ export function FrameworkSelector({
   ...rest
 }) {
   const links = [...coreFrameworks, ...communityFrameworks].map((f) => ({
-    framework,
+    framework: f,
     LinkWrapper: GatsbyLinkWrapper,
     href: buildPathWithFramework(slug, f),
     title: (

--- a/src/components/screens/DocsScreen/VersionCTA.stories.tsx
+++ b/src/components/screens/DocsScreen/VersionCTA.stories.tsx
@@ -23,7 +23,8 @@ export const OldVersion = Template.bind({});
 OldVersion.args = {
   framework: coreFrameworks[0],
   version: versions.stable[1].version,
-  latestVersion: Number(versions.stable[0].string),
+  latestVersion: versions.stable[0].version,
+  latestVersionString: versions.stable[0].string,
   versions,
   slug: '/docs/get-started/introduction',
 };

--- a/src/components/screens/DocsScreen/VersionCTA.tsx
+++ b/src/components/screens/DocsScreen/VersionCTA.tsx
@@ -6,7 +6,15 @@ import GatsbyLink from '../../basics/GatsbyLink';
 import buildPathWithFramework from '../../../util/build-path-with-framework';
 import { VersionSelector } from './VersionSelector';
 
-export function VersionCTA({ framework, version, latestVersion, slug, versions, ...rest }) {
+export function VersionCTA({
+  framework,
+  version,
+  latestVersion,
+  latestVersionString,
+  slug,
+  versions,
+  ...rest
+}) {
   let message = `You're viewing older docs for version ${version.toFixed(1)}.`;
   let badge = <Badge status="positive">New</Badge>;
 
@@ -29,7 +37,7 @@ export function VersionCTA({ framework, version, latestVersion, slug, versions, 
   return (
     <OutlineCTA
       action={
-        <GatsbyLink to={buildPathWithFramework(slug, framework)} withArrow>
+        <GatsbyLink to={buildPathWithFramework(slug, framework, latestVersionString)} withArrow>
           View latest docs
         </GatsbyLink>
       }

--- a/src/util/build-path-with-framework.js
+++ b/src/util/build-path-with-framework.js
@@ -1,4 +1,4 @@
-const { versionString, latestVersionString } = require('../../site-metadata');
+const { versionString, latestVersionString } = require('./version-data');
 
 module.exports = function buildPathWithFramework(slug, framework, overrideVersion) {
   const version = overrideVersion || versionString;

--- a/src/util/version-data.js
+++ b/src/util/version-data.js
@@ -1,0 +1,16 @@
+const { version: versionFull } = require('../generated/versions/current/package.json');
+const { version: latestVersionFull } = require('../generated/versions/latest/package.json');
+
+const VERSION_PARTS_REGEX = /^(\d+\.\d+)(?:\.\d+)?-?(\w+)?(?:\.\d+$)?/;
+const [, versionString] = versionFull.match(VERSION_PARTS_REGEX);
+const version = parseFloat(versionString);
+const [, latestVersionString] = latestVersionFull.match(VERSION_PARTS_REGEX);
+const latestVersion = parseFloat(latestVersionString);
+
+module.exports = {
+  version,
+  versionString,
+  latestVersion,
+  latestVersionString,
+  isLatest: version === latestVersion,
+};


### PR DESCRIPTION
- Move version data out of site-metadata
    - site-metadata is imported by other projects
    - versions data is built from imported files that aren't present in those other projects
- Fix redirect from /docs (no trailing slash)
    - Remove Gatsby redirects; use Netlify redirects
- Fix broken "View latest docs" link in VersionCTA
- Fix broken Framework selector