### PR TITLE
Fix redirects

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -164,7 +164,6 @@ exports.createPages = ({ actions, graphql }) => {
             ({ node: aNode }, { node: bNode }) =>
               parseFloat(aNode.fields.version) - parseFloat(bNode.fields.version)
           );
-          let latestRelease;
           sortedReleases.forEach(({ node }) => {
             const { pageType, iframeSlug, slug, version: releaseVersion } = node.fields;
             // Data passed to context is available in page queries as GraphQL variables.
@@ -186,21 +185,7 @@ exports.createPages = ({ actions, graphql }) => {
                 layout: 'iframe',
               },
             });
-
-            if (!node.frontmatter.prerelease) {
-              latestRelease = node;
-            }
           });
-
-          // Leave a /releases/ endpoint, but redirect it to the latest version
-          if (latestRelease) {
-            createRedirect({
-              fromPath: `/releases/`,
-              isPermanent: false,
-              redirectInBrowser: true,
-              toPath: latestRelease.fields.slug,
-            });
-          }
 
           frameworks = [...coreFrameworks, ...communityFrameworks];
           const docsPagesSlugs = [];
@@ -317,10 +302,13 @@ function updateRedirectsFile() {
 
       if (!isLatestLocal) {
         acc.push(`/docs/${string}/* ${versionBranch}/docs/${versionStringLocal}/:splat 200`);
+      } else {
+        acc.push(`/docs/${versionStringLocal}/* /docs/:splat 301`);
       }
 
       return acc;
     }, [])
+    .concat([`/releases /releases/${latestVersionString} 301`])
     .join('\n');
   fs.writeFileSync('./public/_redirects', `${originalContents}\n\n${newContents}`);
 }


### PR DESCRIPTION
- Add `/docs/<latest>/...` -> `/docs/...`
    - Without this, there could be links that include the next version (e.g. `6.4`) out in the wild that would 404 once that version goes stable.
- Move `/releases` -> `/releases/<latest>` out of Gatsby and into Netlify

Here's a diff showing the generated output in the `/public/_redirects` file.

```diff
/docs /docs/react/get-started/introduction 301
/docs/react /docs/react/get-started/introduction 301
/docs/vue /docs/vue/get-started/introduction 301
/docs/angular /docs/angular/get-started/introduction 301
/docs/web-components /docs/web-components/get-started/introduction 301
/docs/ember /docs/ember/get-started/introduction 301
/docs/html /docs/html/get-started/introduction 301
/docs/mithril /docs/mithril/get-started/introduction 301
/docs/marko /docs/marko/get-started/introduction 301
/docs/svelte /docs/svelte/get-started/introduction 301
/docs/riot /docs/riot/get-started/introduction 301
/docs/preact /docs/preact/get-started/introduction 301
/docs/rax /docs/rax/get-started/introduction 301
+ /docs/6.3/* /docs/:splat 301
/docs/6.2 https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/react/get-started/introduction 301
/docs/6.2/react https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/react/get-started/introduction 301
/docs/6.2/vue https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/vue/get-started/introduction 301
/docs/6.2/angular https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/angular/get-started/introduction 301
/docs/6.2/web-components https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/web-components/get-started/introduction 301
/docs/6.2/ember https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/ember/get-started/introduction 301
/docs/6.2/html https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/html/get-started/introduction 301
/docs/6.2/mithril https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/mithril/get-started/introduction 301
/docs/6.2/marko https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/marko/get-started/introduction 301
/docs/6.2/svelte https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/svelte/get-started/introduction 301
/docs/6.2/riot https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/riot/get-started/introduction 301
/docs/6.2/preact https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/preact/get-started/introduction 301
/docs/6.2/rax https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/rax/get-started/introduction 301
/docs/6.2/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
/docs/6.1 https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/react/get-started/introduction 301
/docs/6.1/react https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/react/get-started/introduction 301
/docs/6.1/vue https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/vue/get-started/introduction 301
/docs/6.1/angular https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/angular/get-started/introduction 301
/docs/6.1/web-components https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/web-components/get-started/introduction 301
/docs/6.1/ember https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/ember/get-started/introduction 301
/docs/6.1/html https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/html/get-started/introduction 301
/docs/6.1/mithril https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/mithril/get-started/introduction 301
/docs/6.1/marko https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/marko/get-started/introduction 301
/docs/6.1/svelte https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/svelte/get-started/introduction 301
/docs/6.1/riot https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/riot/get-started/introduction 301
/docs/6.1/preact https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/preact/get-started/introduction 301
/docs/6.1/rax https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/rax/get-started/introduction 301
/docs/6.1/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
/docs/6.0 https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/react/get-started/introduction 301
/docs/6.0/react https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/react/get-started/introduction 301
/docs/6.0/vue https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/vue/get-started/introduction 301
/docs/6.0/angular https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/angular/get-started/introduction 301
/docs/6.0/web-components https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/web-components/get-started/introduction 301
/docs/6.0/ember https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/ember/get-started/introduction 301
/docs/6.0/html https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/html/get-started/introduction 301
/docs/6.0/mithril https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/mithril/get-started/introduction 301
/docs/6.0/marko https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/marko/get-started/introduction 301
/docs/6.0/svelte https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/svelte/get-started/introduction 301
/docs/6.0/riot https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/riot/get-started/introduction 301
/docs/6.0/preact https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/preact/get-started/introduction 301
/docs/6.0/rax https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/rax/get-started/introduction 301
/docs/6.0/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
/docs/6.4 https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/react/get-started/introduction 301
/docs/6.4/react https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/react/get-started/introduction 301
/docs/6.4/vue https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/vue/get-started/introduction 301
/docs/6.4/angular https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/angular/get-started/introduction 301
/docs/6.4/web-components https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/web-components/get-started/introduction 301
/docs/6.4/ember https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/ember/get-started/introduction 301
/docs/6.4/html https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/html/get-started/introduction 301
/docs/6.4/mithril https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/mithril/get-started/introduction 301
/docs/6.4/marko https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/marko/get-started/introduction 301
/docs/6.4/svelte https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/svelte/get-started/introduction 301
/docs/6.4/riot https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/riot/get-started/introduction 301
/docs/6.4/preact https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/preact/get-started/introduction 301
/docs/6.4/rax https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/rax/get-started/introduction 301
/docs/6.4/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
/docs/7.0 https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/react/get-started/introduction 301
/docs/7.0/react https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/react/get-started/introduction 301
/docs/7.0/vue https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/vue/get-started/introduction 301
/docs/7.0/angular https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/angular/get-started/introduction 301
/docs/7.0/web-components https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/web-components/get-started/introduction 301
/docs/7.0/ember https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/ember/get-started/introduction 301
/docs/7.0/html https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/html/get-started/introduction 301
/docs/7.0/mithril https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/mithril/get-started/introduction 301
/docs/7.0/marko https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/marko/get-started/introduction 301
/docs/7.0/svelte https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/svelte/get-started/introduction 301
/docs/7.0/riot https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/riot/get-started/introduction 301
/docs/7.0/preact https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/preact/get-started/introduction 301
/docs/7.0/rax https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/rax/get-started/introduction 301
/docs/7.0/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
/docs/next https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/react/get-started/introduction 301
/docs/next/react https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/react/get-started/introduction 301
/docs/next/vue https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/vue/get-started/introduction 301
/docs/next/angular https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/angular/get-started/introduction 301
/docs/next/web-components https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/web-components/get-started/introduction 301
/docs/next/ember https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/ember/get-started/introduction 301
/docs/next/html https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/html/get-started/introduction 301
/docs/next/mithril https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/mithril/get-started/introduction 301
/docs/next/marko https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/marko/get-started/introduction 301
/docs/next/svelte https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/svelte/get-started/introduction 301
/docs/next/riot https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/riot/get-started/introduction 301
/docs/next/preact https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/preact/get-started/introduction 301
/docs/next/rax https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/rax/get-started/introduction 301
/docs/next/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+ /releases /releases/6.3 301
```