### PR TITLE
Setup explicit, manual, SSR for Emotion

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,11 @@
+import React from 'react';
+import { CacheProvider } from '@storybook/theming';
+import createCache from '@emotion/cache';
+
+const EMOTION_KEY = 'chr';
+
 /* eslint-env browser */
-exports.onRouteUpdate = ({ location, prevLocation }) => {
+export const onRouteUpdate = ({ location, prevLocation }) => {
   if (
     location.pathname.match(/iframe/) ||
     !window.analytics ||
@@ -14,3 +20,10 @@ exports.onRouteUpdate = ({ location, prevLocation }) => {
 
   window.analytics.page();
 };
+
+const cache = createCache({ key: EMOTION_KEY });
+cache.compat = true;
+
+export const wrapRootElement = ({ element }) => (
+  <CacheProvider value={cache}>{element}</CacheProvider>
+);

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,4 +4,31 @@
  * See: https://www.gatsbyjs.org/docs/ssr-apis/
  */
 
-// You can delete this file if you're not using it
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { CacheProvider } from '@storybook/theming';
+import createCache from '@emotion/cache';
+import createEmotionServer from 'create-emotion-server';
+
+const EMOTION_KEY = 'chr';
+
+export const replaceRenderer = ({ setHeadComponents, replaceBodyHTMLString, bodyComponent }) => {
+  const cache = createCache({ key: EMOTION_KEY });
+  cache.compat = true;
+
+  const { extractCritical } = createEmotionServer(cache);
+  const { ids, css, html } = extractCritical(
+    renderToString(<CacheProvider value={cache}>{bodyComponent}</CacheProvider>)
+  );
+
+  setHeadComponents([
+    <style
+      {...{
+        [`data-emotion-${EMOTION_KEY}`]: ids.join(' '),
+        dangerouslySetInnerHTML: { __html: css },
+      }}
+    />,
+  ]);
+
+  replaceBodyHTMLString(html);
+};


### PR DESCRIPTION
Emotion comes with 0-config SSR - by default one doesn't have to configure it anyhow, integrate with it etc. However, it comes with a price - some selectors might not work properly. The problem is that to achieve that we render `<style/>` elements "inline" and we move them to `<head/>` on the client-side.

So for example something like this might accidentally target such "inline" `<style/>`:
https://github.com/storybookjs/frontpage/blob/f92ce565a8bcab80845a374e5cf873519bbd7d39/src/components/layout/DocsLayout.js#L81
This gets fixed when the element gets moved to `<head/>` but it leaves the site with an ugly SSR blink, like the reported one, before client-side JS kicks in.

This particular problem could probably be fixed with something like this:
<details>
<summary>git diff</summary>

```diff
diff --git a/src/components/layout/DocsLayout.js b/src/components/layout/DocsLayout.js
index 05eadd3..b267f00 100644
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -58,6 +58,9 @@ const ExpandButton = styled(Button)`
   width: 36px;
 `;
 
+const StyledVersionSelector = styled(VersionSelector)``;
+const StyledFrameworkSelector = styled(FrameworkSelector)``;
+
 const SidebarControls = styled.div`
   display: flex;
   align-items: center;
@@ -74,16 +77,16 @@ const SidebarControls = styled.div`
       margin-right: 10px;
     }
   }
-  /* button */
-  > *:nth-child(2) {
+
+  > ${ExpandButton} {
     display: none;
     @media (min-width: ${breakpoint * 1.333}px) {
       display: inline-block;
       flex: none;
     }
   }
-  /* version picker */
-  > *:nth-child(3) {
+
+  > ${StyledVersionSelector} {
     order: 3;
     @media (min-width: ${breakpoint * 1.333}px) {
       flex: 0 0 100%;
@@ -92,8 +95,8 @@ const SidebarControls = styled.div`
       margin-top: 1.5rem;
     }
   }
-  /* framework picker */
-  > *:nth-child(4) {
+
+  > ${StyledFrameworkSelector} {
     margin-left: 10px;
     margin-right: 10px;
     order: 2;
@@ -251,14 +254,14 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext, ...props })
                     </WithTooltip>
                   )}
 
-                  <VersionSelector
+                  <StyledVersionSelector
                     version={version}
                     versions={versions}
                     framework={framework}
                     slug={slug}
                   />
 
-                  <FrameworkSelector
+                  <StyledFrameworkSelector
                     framework={framework}
                     coreFrameworks={coreFrameworks}
                     communityFrameworks={communityFrameworks}

```
</details>

However, I was worried that you might still have some other problems elsewhere, or some random~ layout shifts after SSR, as the codebase has a couple of those "unsafe" selectors. So I've decided to just fix this once and for all - by opting into the explicit SSR setup.