### PR TITLE
Add /showcase proxy rewrite

### DIFF
--- a/src/util/redirects-raw.txt
+++ b/src/util/redirects-raw.txt
@@ -9,3 +9,4 @@
 /docs/workflows/storybook-composition/           /docs/sharing/storybook-composition/                                           301
 /docs/workflows/package-composition/             /docs/sharing/package-composition/                                             301
 /docs/workflows/faq/                             /docs/faq/                                                                     301
+/docs/get-started/examples                       /showcase                                                                      301

--- a/static/_redirects
+++ b/static/_redirects
@@ -84,8 +84,9 @@
 # Other
 /versions.json                              /.netlify/functions/versions/:splat                                            200
 /blog/*                                     https://storybook-blog.netlify.app/blog/:splat                                 200
+/showcase/*                                 https://storybook-component-catalog.netlify.app/showcase/:splat                200
 /tutorials/*                                https://storybook-tutorials.netlify.app/tutorials/:splat                       200
 
-/design-system                              https://5ccbc373887ca40020446347-oghpnhotjv.chromatic.com
+/design-system                              https://master--5ccbc373887ca40020446347.chromatic.com
 
 # Rest of this file is generated (see gatsby-node.js > updateRedirectsFile)


### PR DESCRIPTION
- Redirect /docs/<framework>/get-started/examples to /showcase
- Ensure /design-system always points to latest Chromatic build