### PR TITLE
Update generated `sitemap-all.xml`

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,7 +9,7 @@ const buildPathWithFramework = require('./src/util/build-path-with-framework');
 const createAddonsPages = require('./src/util/create-addons-pages');
 const getReleaseBranchUrl = require('./src/util/get-release-branch-url');
 const { versionString, latestVersionString, isLatest } = require('./src/util/version-data');
-const versions = require('./src/util/versions');
+const { versions } = require('./src/util/versions');
 
 const docsTocWithPaths = addStateToToc(docsToc);
 

--- a/scripts/extract-monorepo-version.sh
+++ b/scripts/extract-monorepo-version.sh
@@ -19,6 +19,7 @@ echo "Extracting $LABEL version info..."
 
 mkdir -p "$VERSIONS_DIR/$LABEL"
 
-curl $MONOREPO_CODELOAD_URL/$BRANCH_ARG | tar -zxvC $VERSIONS_DIR "$TAR_NAME/package.json"
+curl $MONOREPO_CODELOAD_URL/$BRANCH_ARG | tar -zxvC $VERSIONS_DIR "$TAR_NAME/package.json" "$TAR_NAME/docs/toc.js"
 mv "$VERSIONS_DIR/$TAR_NAME/package.json" "$VERSIONS_DIR/$LABEL/package.json"
+mv "$VERSIONS_DIR/$TAR_NAME/docs/toc.js" "$VERSIONS_DIR/$LABEL/toc.js"
 rm -r "$VERSIONS_DIR/$TAR_NAME"

--- a/src/util/versions.js
+++ b/src/util/versions.js
@@ -1,8 +1,40 @@
+/* eslint-disable global-require, import/no-dynamic-require */
 const fs = require('fs');
 
-const { versionString, latestVersion, latestVersionString, isLatest } = require('./version-data');
+const { latestVersion, latestVersionString } = require('./version-data');
 
 const VERSION_PARTS_REGEX = /^(\d+\.\d+)(?:\.\d+)?-?(\w+)?(?:\.\d+$)?/;
+
+/* Creates a structure like:
+ *
+ *  [
+ *    { "version": 7, "string": "7.0", "label": "alpha", "toc": [...] },
+ *    { "version": 6.4, "string": "6.4", "label": "beta", "toc": [...] },
+ *    { "version": 6.2, "string": "6.2", "toc": [...] },
+ *    { "version": 6.1, "string": "6.1", "toc": [...] },
+ *    { "version": 6, "string": "6.0", "toc": [...] },
+ *  ]
+ *
+ * The simple sorting logic will break if the minor version number is >= 10, e.g. 6.10.
+ * That seems very unlikely, given our release cadence, so we opted to keep it simple.
+ *
+ * Note that the output does not include the latest (6.3, in this example) version.
+ */
+const versionsWithToc = fs
+  .readdirSync('./src/generated/versions')
+  .filter((v) => v.match(VERSION_PARTS_REGEX))
+  .sort((a, b) => parseFloat(b || latestVersion) - parseFloat(a || latestVersion))
+  .map((v) => {
+    const { version: versionFromFile } = require(`../generated/versions/${v}/package.json`);
+    const { toc } = require(`../generated/versions/${v}/toc.js`);
+    const [, string, label] = versionFromFile.match(VERSION_PARTS_REGEX);
+    return {
+      version: Number(string),
+      string,
+      label,
+      toc,
+    };
+  });
 
 /* Creates a structure like:
  *
@@ -20,37 +52,20 @@ const VERSION_PARTS_REGEX = /^(\d+\.\d+)(?:\.\d+)?-?(\w+)?(?:\.\d+$)?/;
  *  }
  *
  * Note that the stable releases are sorted in descending order, and pre-releases in ascending.
- *
- * The simple sorting logic will break if the minor version number is >= 10, e.g. 6.10.
- * That seems very unlikely, given our release cadence, so we opted to keep it simple.
  */
-const versions = fs
-  .readdirSync('./src/generated/versions')
-  .filter((v) => v.match(VERSION_PARTS_REGEX))
-  .sort((a, b) => parseFloat(b || latestVersion) - parseFloat(a || latestVersion))
-  .map((v) => {
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    const { version: versionFromFile } = require(`../generated/versions/${v}/package.json`);
-    const [, string, label] = versionFromFile.match(VERSION_PARTS_REGEX);
-    return {
-      version: Number(string),
-      string,
-      label,
-    };
-  })
-  .reduce(
-    (acc, v) => {
-      if (v.version > latestVersion) {
-        acc.preRelease.unshift(v);
-      } else {
-        acc.stable.push(v);
-      }
-      return acc;
-    },
-    {
-      stable: [{ version: latestVersion, label: 'latest', string: latestVersionString }],
-      preRelease: [],
+const versions = versionsWithToc.reduce(
+  (acc, v) => {
+    if (v.version > latestVersion) {
+      acc.preRelease.unshift(v);
+    } else {
+      acc.stable.push(v);
     }
-  );
+    return acc;
+  },
+  {
+    stable: [{ version: latestVersion, label: 'latest', string: latestVersionString }],
+    preRelease: [],
+  }
+);
 
-module.exports = versions;
+module.exports = { versionsWithToc, versions };

--- a/static/_redirects
+++ b/static/_redirects
@@ -7,9 +7,9 @@
 /basics/guide-react-native                  https://github.com/storybookjs/react-native#storybook-for-react-native         301
 /basics/guide-vue                           /docs/vue/                                                                     301
 /basics/guide-angular                       /docs/angular/                                                                 301
-/basics/guide-mithril                       /docs/mithril/                                                                 301
+/basics/guide-mithril                       /docs/                                                                         301
 /basics/guide-ember                         /docs/ember/                                                                   301
-/basics/guide-riot                          /docs/riot/                                                                    301
+/basics/guide-riot                          /docs/                                                                         301
 /basics/guide-html                          /docs/html/                                                                    301
 /docs/basics/quick-start-guide              /docs/react/get-started/install/                                               301
 /docs/basics/slow-start-guide               /docs/react/configure/overview/                                                301
@@ -17,9 +17,9 @@
 /docs/basics/guide-react-native             https://github.com/storybookjs/react-native#storybook-for-react-native         301
 /docs/basics/guide-vue                      /docs/vue/                                                                     301
 /docs/basics/guide-angular                  /docs/angular/                                                                 301
-/docs/basics/guide-mithril                  /docs/mithril/                                                                 301
+/docs/basics/guide-mithril                  /docs/                                                                         301
 /docs/basics/guide-ember                    /docs/ember/                                                                   301
-/docs/basics/guide-riot                     /docs/riot/                                                                    301
+/docs/basics/guide-riot                     /docs/                                                                         301
 /docs/basics/guide-html                     /docs/html/                                                                    301
 
 /basics/*                                   /docs/basics/:splat                                                            301
@@ -44,10 +44,15 @@
 /docs/guides/guide-react-native/            https://github.com/storybookjs/react-native#storybook-for-react-native         301
 /docs/guides/guide-vue/                     /docs/vue/                                                                     301
 /docs/guides/guide-angular/                 /docs/angular/                                                                 301
-/docs/guides/guide-mithril/                 /docs/mithril/                                                                 301
-/docs/guides/guide-marko/                   /docs/marko/                                                                   301
+/docs/guides/guide-mithril/                 /docs/                                                                         301
+/docs/mithril/                              /docs/                                                                         301
+/docs/guides/guide-marko/                   /docs/                                                                         301
+/docs/marko/                                /docs/                                                                         301
 /docs/guides/guide-ember/                   /docs/ember/                                                                   301
-/docs/guides/guide-riot/                    /docs/riot/                                                                    301
+/docs/guides/guide-rax/                     /docs/                                                                         301
+/docs/rax/                                  /docs/                                                                         301
+/docs/guides/guide-riot/                    /docs/                                                                         301
+/docs/riot/                                 /docs/                                                                         301
 /docs/guides/guide-svelte/                  /docs/svelte/                                                                  301
 /docs/guides/guide-preact/                  /docs/preact/                                                                  301
 


### PR DESCRIPTION
- Extract `docs/toc.js` from each docs version
- Use those TOCs to generate a sitemap that only includes pages that are present within each version

-----

You can see the generated file here: https://deploy-preview-344--storybook-frontpage.netlify.app/sitemap-all.xml

Note the pages it contains, for a slug like `/sharing/publish-storybook`, which is present in the "latest" and "next" TOC, but not any others (at the moment):

- ✅  https://storybook.js.org/docs/react/sharing/publish-storybook
- ✅  https://storybook.js.org/docs/6.5/react/sharing/publish-storybook
- ❌  https://storybook.js.org/docs/6.3/react/sharing/publish-storybook
- ❌  https://storybook.js.org/docs/7.0/react/sharing/publish-storybook