### PR TITLE
Remove extra spacing from top of BlogCTA on desktop

### DIFF
--- a/src/components/screens/IndexScreen/IndexScreen.js
+++ b/src/components/screens/IndexScreen/IndexScreen.js
@@ -28,10 +28,6 @@ const BlogCTAWrapper = styled.div`
   display: flex;
   justify-content: center;
   padding: 20px ${styles.spacing.padding.medium}px 0;
-
-  @media (min-width: ${breakpoint * 1}px) {
-    padding-top: 40px;
-  }
 `;
 
 const Contrast = styled.div`


### PR DESCRIPTION
Minor one line change to revert previous styling tweak for BlogCTA spacing on desktop. 