### PR TITLE
Fix word-break

### DIFF
--- a/src/components/layout/addons/AddonItem.js
+++ b/src/components/layout/addons/AddonItem.js
@@ -120,6 +120,7 @@ Description.propTypes = {
 const AddonInfo = styled.div`
   display: flex;
   align-items: flex-start;
+  word-break: break-word;
 
   @media (min-width: ${breakpoint * 1.5}px) {
     ${(props) =>


### PR DESCRIPTION
- Fix AddonItem component word-break.

- Before: 
<img width="879" alt="截圖 2022-06-18 下午3 47 54" src="https://user-images.githubusercontent.com/48987435/174428314-f8170808-d651-439f-910e-522139305dc4.png">

- After:
<img width="848" alt="截圖 2022-06-18 下午3 51 38" src="https://user-images.githubusercontent.com/48987435/174428464-e810c4a3-360e-421d-977a-55e5c820581f.png">

