### PR TITLE
Copy other sitemaps into /public & update index

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -190,12 +190,17 @@ module.exports = {
                   }
                 }
               `,
-              resolvePages: ({ site, allSitePage: { nodes: allPages } }) =>
+              resolvePages: ({
+                site: {
+                  siteMetadata: { siteUrl },
+                },
+                allSitePage: { nodes: allPages },
+              }) =>
                 allPages.map((page) => ({
-                  url: `${site.siteMetadata.siteUrl}${page.path}/`,
+                  url: `${siteUrl}${page.path}/`,
                   ...page,
                 })),
-              serialize: ({ url }) => ({ url, changefreq: 'daily', priority: 0.7 }),
+              serialize: ({ url }) => ({ url }),
               // Exclude all doc pages not for React
               // except the get-started/introduction page for all frameworks
               excludes: [
@@ -224,9 +229,14 @@ module.exports = {
                   }
                 }
               `,
-              resolvePages: ({ site, allSitePage: { nodes: allPages } }) => {
+              resolvePages: ({
+                site: {
+                  siteMetadata: { siteUrl },
+                },
+                allSitePage: { nodes: allPages },
+              }) => {
                 const latestPages = allPages.map((page) => ({
-                  url: `${site.siteMetadata.siteUrl}${page.path}/`,
+                  url: `${siteUrl}${page.path}/`,
                   ...page,
                 }));
 
@@ -242,8 +252,8 @@ module.exports = {
 
                           if (pathSegment) {
                             nonLatestDocsPages.push({
-                              url: `${site.siteMetadata.siteUrl}${pagePath}/`,
-                              path: `${site.siteMetadata.siteUrl}${pagePath}/`,
+                              url: `${siteUrl}${pagePath}/`,
+                              path: `${pagePath}/`,
                             });
                           }
 
@@ -265,7 +275,7 @@ module.exports = {
 
                 return [...latestPages, ...nonLatestDocsPages];
               },
-              serialize: ({ url }) => ({ url, changefreq: 'daily', priority: 0.7 }),
+              serialize: ({ url }) => ({ url }),
             },
           },
         ]

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: 
+
+Sitemap: https://storybook.js.org/sitemap/sitemap-index.xml


### PR DESCRIPTION
- Included other sitemaps:
    - [/showcase/sitemap-0.xml](https://storybook.js.org/showcase/sitemap-0.xml)
    - [/tutorials/sitemap.xml](https://storybook.js.org/tutorials/sitemap.xml)
- Blog sitemaps are temporarily excluded
    - The original sitemaps are incorrect (missing `/blog/` directory)
        - https://storybook.js.org/blog/sitemap-pages.xml
        - https://storybook.js.org/blog/sitemap-posts.xml
        - https://storybook.js.org/blog/sitemap-tags.xml
    - I'm also not sure we _want_ to include all of those (e.g. probably not the `pages` one?)

### Index, before

```xml
<?xml version="1.0" encoding="UTF-8"?>
  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://storybook.js.org/sitemap/sitemap-0.xml</loc>
  </sitemap>
</sitemapindex>
```

### Index, after

```xml
<?xml version="1.0" encoding="UTF-8"?>
  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://storybook.js.org/sitemap/sitemap-0.xml</loc>
    <loc>https://storybook.js.org/sitemap/showcase/sitemap-0.xml</loc>
    <loc>https://storybook.js.org/sitemap/tutorials/sitemap.xml</loc>
  </sitemap>
</sitemapindex>
```