### PR TITLE
Only include canonical URLs for "latest" doc pages

### DIFF
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -200,14 +200,16 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext, ...props })
     <>
       <GlobalStyle />
       <Helmet>
-        <link
-          rel="canonical"
-          href={`${homepageUrl}${buildPathWithFramework(
-            slug,
-            canonicalFramework,
-            latestVersionString
-          )}/`}
-        />
+        {version === latestVersion && (
+          <link
+            rel="canonical"
+            href={`${homepageUrl}${buildPathWithFramework(
+              slug,
+              canonicalFramework,
+              latestVersionString
+            )}/`}
+          />
+        )}
         <meta name="docsearch:framework" content={framework} />
         <meta name="docsearch:version" content={versionString} />
         <link


### PR DESCRIPTION
- Versioned pages may have a `slug` that no longer exists, leading to a 404
- Versioned pages are noIndex'd, so there's no SEO penalty