### PR TITLE
Seo updates

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -333,8 +333,10 @@ function updateSitemapIndex() {
 }
 
 exports.onPostBuild = async () => {
-  await copyOtherSitemaps();
-  updateSitemapIndex();
-  generateVersionsFile();
-  updateRedirectsFile();
+  if (isLatest) {
+    await copyOtherSitemaps();
+    updateSitemapIndex();
+    generateVersionsFile();
+    updateRedirectsFile();
+  }
 };

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -200,14 +200,16 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext, ...props })
     <>
       <GlobalStyle />
       <Helmet>
-        <link
-          rel="canonical"
-          href={`${homepageUrl}${buildPathWithFramework(
-            slug,
-            canonicalFramework,
-            latestVersionString
-          )}/`}
-        />
+        {version === latestVersion && (
+          <link
+            rel="canonical"
+            href={`${homepageUrl}${buildPathWithFramework(
+              slug,
+              canonicalFramework,
+              latestVersionString
+            )}/`}
+          />
+        )}
         <meta name="docsearch:framework" content={framework} />
         <meta name="docsearch:version" content={versionString} />
         <link

--- a/src/util/redirects-raw.txt
+++ b/src/util/redirects-raw.txt
@@ -1,3 +1,4 @@
+/docs/writing-docs/doc-blocks/                   /docs/writing-docs/doc-block-argstable                                         301
 /docs/workflows/testing-with-storybook/          /docs/writing-tests/introduction/                                              301
 /docs/workflows/unit-testing/                    /docs/writing-tests/importing-stories-in-tests/                                301
 /docs/workflows/visual-testing/                  /docs/writing-tests/visual-testing/                                            301
@@ -10,3 +11,6 @@
 /docs/workflows/package-composition/             /docs/sharing/package-composition/                                             301
 /docs/workflows/faq/                             /docs/faq/                                                                     301
 /docs/configure/webpack                          /docs/builders/webpack                                                         301
+/docs/api/addons                                 /docs/addons/introduction                                                      301
+/docs/api/addons-api                             /docs/addons/addons-api                                                        301
+/docs/api/presets                                /docs/addons/writing-presets                                                   301


### PR DESCRIPTION
- Only include canonical URLs for "latest" doc pages
    - Versioned pages may have a `slug` that no longer exists, leading to a 404
    - Versioned pages are noIndex'd, so there's no SEO penalty
- Update redirects