### PR TITLE
Fix sitemap index

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -315,19 +315,15 @@ async function copyOtherSitemaps() {
 }
 /* eslint-enable no-restricted-syntax, no-await-in-loop */
 
-function updateSitemapIndex() {
-  const originalContents = fs.readFileSync('./public/sitemap/sitemap-index.xml');
+async function updateSitemapIndex() {
+  const data = await fs.promises.readFile('./public/sitemap/sitemap-index.xml');
+  const originalContents = data.toString();
 
-  const newLocations = otherSitemaps.map(
-    (sitemap) => `<loc>https://storybook.js.org/sitemap/${sitemap}</loc>`
-  );
+  const newLocations = otherSitemaps
+    .map((sitemap) => `<sitemap><loc>https://storybook.js.org/sitemap/${sitemap}</loc></sitemap>`)
+    .join('');
 
-  const insertIndex = originalContents.indexOf('</sitemap>');
-  const newContent = [
-    originalContents.slice(0, insertIndex),
-    ...newLocations,
-    originalContents.slice(insertIndex),
-  ].join('');
+  const newContent = originalContents.replace(/(<sitemap>.*<\/sitemap>)/, `$1${newLocations}`);
 
   fs.writeFileSync('./public/sitemap/sitemap-index.xml', newContent);
 }
@@ -335,7 +331,7 @@ function updateSitemapIndex() {
 exports.onPostBuild = async () => {
   if (isLatest) {
     await copyOtherSitemaps();
-    updateSitemapIndex();
+    await updateSitemapIndex();
     generateVersionsFile();
     updateRedirectsFile();
   }


### PR DESCRIPTION
- Wrap each `<loc>` in `<sitemap>`

Per https://developers.google.com/search/docs/advanced/sitemaps/large-sitemaps, the format of the sitemap index file has been incorrect since #373.

### Before

```xml
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://storybook.js.org/sitemap/sitemap-0.xml</loc>
    <loc>https://storybook.js.org/sitemap/blog/sitemap.xml</loc>
    <loc>https://storybook.js.org/sitemap/showcase/sitemap-0.xml</loc>
    <loc>https://storybook.js.org/sitemap/tutorials/sitemap.xml</loc>
  </sitemap>
</sitemapindex>
```

### After ([preview](https://deploy-preview-378--storybook-frontpage.netlify.app/sitemap/sitemap-index.xml))

```xml
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://deploy-preview-378--storybook-frontpage.netlify.app/sitemap/sitemap-0.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://storybook.js.org/sitemap/blog/sitemap.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://storybook.js.org/sitemap/showcase/sitemap-0.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://storybook.js.org/sitemap/tutorials/sitemap.xml</loc>
  </sitemap>
</sitemapindex>
```