### PR TITLE
Fix type of `version` prop for DocsSearch

### DIFF
--- a/src/components/screens/DocsScreen/DocsSearch.stories.tsx
+++ b/src/components/screens/DocsScreen/DocsSearch.stories.tsx
@@ -41,6 +41,7 @@ const Template = (args) => <DocsSearch {...args} />;
 export const Default = Template.bind({});
 Default.args = {
   framework: coreFrameworks[0],
+  version: '6.4',
   visible: true,
 };
 Default.decorators = [(storyFn) => <Wrapper>{storyFn()}</Wrapper>];

--- a/src/components/screens/DocsScreen/DocsSearch.tsx
+++ b/src/components/screens/DocsScreen/DocsSearch.tsx
@@ -12,7 +12,7 @@ const ALGOLIA_API_KEY = process.env.GATSBY_ALGOLIA_API_KEY;
 
 interface DocsSearchProps {
   framework: string;
-  version: number;
+  version: string;
   /** Only used for Storybook */
   visible?: boolean;
 }


### PR DESCRIPTION
The only reason this hasn't broken the actual experience is because we've passed `versionString` where it's actually used (https://github.com/storybookjs/frontpage/blob/master/src/components/layout/DocsLayout.js#L231). That file isn't in TypeScript, so this type error wasn't caught. 😅 