### PR TITLE
Fix Storybook demo hero for Safari iOS

### DIFF
--- a/src/components/screens/IndexScreen/StorybookDemo/HeroDemo.tsx
+++ b/src/components/screens/IndexScreen/StorybookDemo/HeroDemo.tsx
@@ -31,8 +31,9 @@ const Wrapper = styled(motion.div)`
   padding-bottom: 69.10907577%;
   overflow: hidden;
 
-  filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.1)) drop-shadow(0px 10px 20px rgba(0, 0, 0, 0.1))
-    drop-shadow(0px 20px 40px rgba(0, 0, 0, 0.05)) drop-shadow(0px 40px 30px rgba(0, 0, 0, 0.05));
+  border-radius: 10px;
+  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.1), 0px 10px 20px rgba(0, 0, 0, 0.1),
+    0px 20px 40px rgba(0, 0, 0, 0.05), 0px 40px 30px rgba(0, 0, 0, 0.05);
 
   @media (min-width: ${breakpoints[1]}px) {
     margin-top: -12.625rem;


### PR DESCRIPTION
For some reason, the filter property causes Safari mobile to have problems rendering our pointer SVG above the storybook demo images.

using `box-shadow` and `border-radius` to create the shadow of the browser fixes this issue.

## Screenshots

### Before
![Simulator Screen Recording - iPhone 14 Pro Max - 2022-09-16 at 11 59 57](https://user-images.githubusercontent.com/18172605/190681427-4d5539a4-bbbc-404c-95b8-94d1d2c2bad0.gif)

### After
![Simulator Screen Recording - iPhone 14 Pro Max - 2022-09-16 at 12 03 07](https://user-images.githubusercontent.com/18172605/190682038-83f104f6-973c-46df-be3a-bdd61ef44c30.gif)

