### PR TITLE
Added muted property

### DIFF
--- a/src/components/layout/Community.js
+++ b/src/components/layout/Community.js
@@ -206,6 +206,7 @@ export function Community({ inverse, ...props }) {
             src={videosA[activeIndex.videoA].src}
             autoPlay
             playsInline
+            muted
           />
         </AnimatePresence>
       </VideoCardALink>
@@ -229,6 +230,7 @@ export function Community({ inverse, ...props }) {
             src={videosB[activeIndex.videoB].src}
             autoPlay
             playsInline
+            muted
           />
         </AnimatePresence>
       </VideoCardBLink>

--- a/src/components/screens/CommunityScreen/CommunitySectionHeader.stories.tsx
+++ b/src/components/screens/CommunityScreen/CommunitySectionHeader.stories.tsx
@@ -10,6 +10,6 @@ export const Default = (args) => <CommunitySectionHeader {...args} />;
 Default.args = {
   title: 'Sponsor the community',
   description:
-    'Donations help the community keep going. They are used for web hosting, continuous integration, contributor swag, learning materials, and event production.',
+    'Donations help keep the community going. They are used for web hosting, continuous integration, contributor swag, learning materials, and event production.',
 };
 Default.storyName = 'CommunitySectionHeader';


### PR DESCRIPTION
Technique from this blog post https://pqina.nl/blog/fix-html-video-autoplay-not-working/

Autoplay can be finicky. These videos weren't autoplaying reliably. Sometimes they were and sometimes they weren't. I added the `muted` prop to match Chrome and Safari's best practices.

How to test: 
1. Go to the published Storybook and search for the CommunityScreen`../screens-communityscreen--default`
2. Check that the videos are autoplaying

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/263385/196501185-9e2cc8ce-283c-4c2b-95dc-4cc3ca504221.png">
