### PR TITLE
Fix sitemap index generation

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -295,12 +295,24 @@ function updateRedirectsFile() {
   fs.writeFileSync('./public/_redirects', `${originalContents}\n\n${redirectsWithFramework}\n\n${versionRedirects}`);
 }
 
-const otherSitemaps = ['blog/sitemap.xml', 'showcase/sitemap-0.xml', 'tutorials/sitemap.xml'];
+const otherSitemaps = [
+  'blog/sitemap/sitemap-0.xml',
+  'showcase/sitemap-0.xml',
+  'tutorials/sitemap/sitemap-0.xml',
+];
+
+function getSitemapId(sitemap) {
+  return sitemap.split('/')[0];
+}
+
+const sitemapFilename = 'sitemap.xml';
 
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
 async function copyOtherSitemaps() {
   for (const sitemap of otherSitemaps) {
-    const directory = `./public/sitemap/${sitemap.split('/')[0]}`;
+    const sitemapId = getSitemapId(sitemap);
+
+    const directory = `./public/sitemap/${sitemapId}`;
     if (!fs.existsSync(directory)) {
       fs.mkdirSync(directory);
     }
@@ -308,7 +320,7 @@ async function copyOtherSitemaps() {
     try {
       const response = await fetch(`https://storybook.js.org/${sitemap}`);
       const content = await response.text();
-      fs.writeFileSync(`./public/sitemap/${sitemap}`, content);
+      fs.writeFileSync(`./public/sitemap/${sitemapId}/${sitemapFilename}`, content);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error);
@@ -322,7 +334,11 @@ async function updateSitemapIndex() {
   const originalContents = data.toString();
 
   const newLocations = otherSitemaps
-    .map((sitemap) => `<sitemap><loc>https://storybook.js.org/sitemap/${sitemap}</loc></sitemap>`)
+    .map(
+      (sitemap) =>
+        // prettier-ignore
+        `<sitemap><loc>https://storybook.js.org/sitemap/${getSitemapId(sitemap)}/${sitemapFilename}</loc></sitemap>`
+    )
     .join('');
 
   const newContent = originalContents.replace(/(<sitemap>.*<\/sitemap>)/, `$1${newLocations}`);


### PR DESCRIPTION
- Correct location of blog & tutorials sitemaps
    - The updates to Gatsby 4 caused the generated sitemaps to now use an index format
        - New sitemaps for each:
            - https://storybook.js.org/blog/sitemap/sitemap-0.xml
            - https://storybook.js.org/tutorials/sitemap/sitemap-0.xml 
- Refactor to handle nested sitemap locations
    - `blog/sitemap.xml` vs. `blog/sitemap/sitemap-0.xml`

The generated index ([preview here](https://deploy-preview-402--storybook-frontpage.netlify.app/sitemap/sitemap-index.xml)) now looks like:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap><loc>https://storybook.js.org/sitemap/sitemap-0.xml</loc></sitemap>
  <sitemap><loc>https://storybook.js.org/sitemap/blog/sitemap.xml</loc></sitemap>
  <sitemap><loc>https://storybook.js.org/sitemap/showcase/sitemap.xml</loc></sitemap>
  <sitemap><loc>https://storybook.js.org/sitemap/tutorials/sitemap.xml</loc></sitemap>
</sitemapindex>
```

And here are the generated sub-indexes:

- [/sitemap/blog/sitemap.xml](https://deploy-preview-402--storybook-frontpage.netlify.app/sitemap/blog/sitemap.xml)
- [/sitemap/showcase/sitemap.xml](https://deploy-preview-402--storybook-frontpage.netlify.app/sitemap/showcase/sitemap.xml)
- [/sitemap/tutorials/sitemap.xml](https://deploy-preview-402--storybook-frontpage.netlify.app/sitemap/tutorials/sitemap.xml)