### PR TITLE
Add security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,12 @@
 [build]
   command = "yarn build:with-prefix"
   functions = "/functions"
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' cdn.segment.io,www.google-analytics.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src *; font-src 'self' fonts.gstatic.com; connect-src 'self' *.segment.io,www.google-analytics.com"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = ""
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "SAMEORIGIN"
+    X-XSS-Protection = "1; mode=block"


### PR DESCRIPTION
Security headers are a bit lacking, this should tune 'em up!

[![Screen Shot 2022-11-01 at 11 20 16 AM](https://user-images.githubusercontent.com/115059/199283815-ff4aba7e-27ad-4c0e-a941-8b517f65da27.png)](https://securityheaders.com/?q=storybook.js.org&followRedirects=on)

There is some risk here, esp. around `Content-Security-Policy`.  We will want to check the preview, and someone with deep familiarity on the site ensure I didn't miss any third party source.