### PR TITLE
Remove jump link from `/why` urls on homepage

### DIFF
--- a/src/components/screens/IndexScreen/Develop.js
+++ b/src/components/screens/IndexScreen/Develop.js
@@ -248,7 +248,7 @@ export function Develop({ docs, startOpen, ...props }) {
               <Link
                 containsIcon
                 withArrow
-                href="/docs/react/why-storybook#the-solution"
+                href="/docs/react/why-storybook"
                 LinkWrapper={GatsbyLinkWrapper}
               >
                 Why build UIs in isolation?
@@ -305,7 +305,7 @@ export function Develop({ docs, startOpen, ...props }) {
               <Link
                 containsIcon
                 withArrow
-                href="/docs/react/why-storybook#the-solution"
+                href="/docs/react/why-storybook"
                 LinkWrapper={GatsbyLinkWrapper}
               >
                 Why build UIs in isolation?


### PR DESCRIPTION
This URL takes you to the middle of the `/why` page which feels like a bug. I removed the jump link so clicking on the URL takes you to the top of the page.
<img width="379" alt="image" src="https://user-images.githubusercontent.com/263385/201457320-8e4c6609-480c-4492-b62b-cd2fa3b25dfb.png">
