### PR TITLE
Highlight anchor links to make them easier to discern

### DIFF
--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -1,6 +1,6 @@
 import { styles } from '@storybook/design-system';
 import { css } from '@storybook/theming';
-import { darken } from 'polished';
+import { darken, rgba } from 'polished';
 
 import { CODE_SNIPPET_CLASSNAME } from '../constants/code-snippets';
 
@@ -30,6 +30,14 @@ export const mdFormatting = css`
     &:hover .remark-header-link svg {
       opacity: 1;
       transition: opacity 250ms ease-out;
+    }
+
+    &:target {
+      background: linear-gradient(
+        90deg,
+        ${rgba(color.secondary, 0.1)} 0%,
+        ${rgba(color.secondary, 0.0)} 70%
+      );
     }
   }
 
@@ -309,6 +317,14 @@ export const mdFormatting = css`
 
     &:not([open]) + details {
       margin-top: -1em;
+    }
+
+    &:target {
+      background: linear-gradient(
+        90deg,
+        ${rgba(color.secondary, 0.1)} 0%,
+        ${rgba(color.secondary, 0.0)} 70%
+      );
     }
   }
 


### PR DESCRIPTION
**Why**
When you click on an anchor link or a `detail`, there is no visual indicator of where you are and what you're supposed to look at. That's confusing when theres a text wall of docs. 

**What**
Added `:target` styles to highlight when anchor links are used. In practice, this means whenever we link to a specific heading or `detail` via a `...#cool-heading` it'll be obvious what the user is supposed to look at.
![2022-11-15 11 41 43](https://user-images.githubusercontent.com/263385/201976609-ee54f361-0495-4cb8-bf8b-acbe5d0fcc94.gif)
