### PR TITLE
Tweak styling: Table of contents, VersionCTA

### DIFF
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -79,6 +79,12 @@ const Wrapper = styled.div`
 `;
 
 const StyledTableOfContents = styled(TableOfContents)`
+  // space the ToC emoji and text
+  li > a svg + span::first-letter,
+  li > button svg + span::first-letter {
+    margin-right: 4px;
+  }
+
   /* Hide ToC on mobile, the primary navigation is search */
   display: none;
 

--- a/src/components/layout/integrations/IntegrationsLayout.js
+++ b/src/components/layout/integrations/IntegrationsLayout.js
@@ -72,6 +72,11 @@ Sidebar.propTypes = {
 };
 
 const ToCContent = styled.div`
+  // space the ToC emoji and text
+  ul > li > a::first-letter {
+    margin-right: 4px;
+  }
+
   /* Hide ToC on mobile, the primary navigation is search */
   display: none;
 

--- a/src/components/screens/CommunityScreen/CommunitySidebar.tsx
+++ b/src/components/screens/CommunityScreen/CommunitySidebar.tsx
@@ -207,6 +207,13 @@ const TabletMenu = styled.div`
   }
 `;
 
+const StyledTableOfContents = styled(TableOfContents)`
+  // space the ToC emoji and text
+  li > a::first-letter {
+    margin-right: 4px;
+  }
+`;
+
 const JumpLink = styled(NavItem)`
   margin-left: auto;
 
@@ -248,7 +255,7 @@ export function CommunitySidebar({ badgeUrl, activeSectionId, ...props }: Commun
       <DesktopWrapper {...props}>
         <Inner>
           <Title>Community</Title>
-          <TableOfContents items={sections} currentPath={activeSection?.path} />
+          <StyledTableOfContents items={sections} currentPath={activeSection?.path} />
           <Divider />
           <BadgeContainer>
             <Text>Get a README badge</Text>

--- a/src/components/screens/DocsScreen/VersionCTA.tsx
+++ b/src/components/screens/DocsScreen/VersionCTA.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Badge, OutlineCTA } from '@storybook/design-system';
+import { styled } from '@storybook/theming';
+import { Badge, OutlineCTA, styles } from '@storybook/design-system';
 import { startCase } from 'lodash';
 import GatsbyLink from '../../basics/GatsbyLink';
 import buildPathWithFramework from '../../../util/build-path-with-framework';
 import { Versions } from './VersionSelector';
 
+const { breakpoint } = styles;
 interface VersionCTAProps {
   framework: string;
   latestVersion: number;
@@ -14,6 +16,18 @@ interface VersionCTAProps {
   versions: Versions;
 }
 
+const StyledOutlineCTA = styled(OutlineCTA)`
+  //override styles from design system
+  @media (min-width: ${breakpoint}px) {
+    padding-left: 15px;
+    padding-right: 10px;
+  }
+
+  ${Badge} {
+    // with inline spacing this yields about 10px between badge and text
+    margin-right: 2px;
+  }
+`;
 export function VersionCTA({
   framework,
   version,
@@ -43,7 +57,7 @@ export function VersionCTA({
   }
 
   return (
-    <OutlineCTA
+    <StyledOutlineCTA
       action={
         <GatsbyLink to={buildPathWithFramework(slug, framework, latestVersionString)} withArrow>
           View latest docs
@@ -53,6 +67,6 @@ export function VersionCTA({
       {...rest}
     >
       {message}
-    </OutlineCTA>
+    </StyledOutlineCTA>
   );
 }


### PR DESCRIPTION
Table of Contents: Added more generous spacing between emoji and text to improve readability

<img width="243" alt="image" src="https://user-images.githubusercontent.com/263385/204583361-c786413a-27eb-4c04-9779-87da1e788321.png">

VersionCTA: adjust spacing to match the YoutubeCallout 
<img width="650" alt="image" src="https://user-images.githubusercontent.com/263385/204588879-ea05d146-6c70-4c0f-aebe-13b7cf0c1aa6.png">
