### PR TITLE
Add border to youtube callout

### DIFF
--- a/src/components/screens/DocsScreen/YouTubeCallout.tsx
+++ b/src/components/screens/DocsScreen/YouTubeCallout.tsx
@@ -17,6 +17,7 @@ const { color, typography, spacing } = styles;
 const Details = styled.details`
   border-radius: ${spacing.borderRadius.small}px;
   box-shadow: 0 2px 5px 0 ${color.border};
+  border: 1px solid ${color.border};
   overflow: hidden;
   cursor: pointer;
 


### PR DESCRIPTION
Add border to YouTubeCallout to improve acuity.

Before: 
<img width="509" alt="image" src="https://user-images.githubusercontent.com/263385/204663342-41a7f815-c7b7-4a8d-b7d9-ec1148e8abc5.png">

After:
<img width="498" alt="image" src="https://user-images.githubusercontent.com/263385/204663272-3759a1d5-a456-45cb-aa9b-b72d29fcdf8a.png">
