### PR TITLE
fix: remove the path splitting due to web-components

### DIFF
--- a/src/components/screens/DocsScreen/FeatureSnippets.tsx
+++ b/src/components/screens/DocsScreen/FeatureSnippets.tsx
@@ -29,8 +29,7 @@ export function FeatureSnippets({ currentFramework, paths }) {
           // See comment in CodeSnippets
           const { default: ModuleComponent } = await import(`../../../content/docs/${path}`);
 
-          const parts = basename(path, '.mdx').split('-');
-          const framework = parts[parts.length - 1];
+          const framework = basename(path, '.mdx');
           return [framework, ModuleComponent];
         })
       );


### PR DESCRIPTION
## Description

The current `.split(-)` code has side effects on dashed framework names like **web-components**.

## Action

The `.split(-)` part is removed from the codebase.


## Related issue
closes #228