### PR TITLE
Add CSF message to CodeSnippets

### DIFF
--- a/src/components/screens/DocsScreen/CodeSnippets.stories.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets.stories.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { styled } from '@storybook/theming';
 import { Highlight } from '@storybook/design-system';
 
-import { PureCodeSnippets, MissingMessage, TabLabel } from './CodeSnippets';
+import { PureCodeSnippets, CsfMessage, MissingMessage, TabLabel } from './CodeSnippets';
 import { mdFormatting } from '../../../styles/formatting';
-import compiledMDX from '../../../../.storybook/compiled-mdx';
 
 const jsCode = `
 // Button.stories.js
@@ -66,6 +65,18 @@ const snippetsWithMissingMessaging = snippets.map((snippet, index) => ({
   Snippet: TSModuleComponent,
 }));
 
+const snippetsWithCsfMessaging = snippets.map((snippet, index) => ({
+  ...snippet,
+  PreSnippet: () => <CsfMessage currentFramework="angular" />,
+  Snippet: TSModuleComponent,
+}));
+
+const snippetsWithCsfMessagingWithExample = snippets.map((snippet, index) => ({
+  ...snippet,
+  PreSnippet: () => <CsfMessage csf2Path="page/path#snippet-anchor" currentFramework="angular" />,
+  Snippet: TSModuleComponent,
+}));
+
 const Wrapper = styled.div`
   ${mdFormatting}
   padding: 10px;
@@ -87,10 +98,25 @@ export const Missing = () => (
   <PureCodeSnippets currentFramework="angular" snippets={[snippetsWithMissingMessaging[0]]} />
 );
 
+export const Csf2 = () => (
+  <PureCodeSnippets currentFramework="angular" snippets={[snippetsWithCsfMessaging[0]]} />
+);
+
+export const Csf2WithExample = () => (
+  <PureCodeSnippets
+    currentFramework="angular"
+    snippets={[snippetsWithCsfMessagingWithExample[0]]}
+  />
+);
+
 export const Multiple = () => <PureCodeSnippets currentFramework="react" snippets={snippets} />;
 
 export const MultipleMissing = () => (
   <PureCodeSnippets currentFramework="angular" snippets={snippetsWithMissingMessaging} />
+);
+
+export const MultipleCsf2 = () => (
+  <PureCodeSnippets currentFramework="angular" snippets={snippetsWithCsfMessaging} />
 );
 
 export const MultipleWithoutBadges = () => (

--- a/src/components/screens/DocsScreen/CodeSnippets.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets.tsx
@@ -18,15 +18,9 @@ const CodeSnippetFramework = styled.span`
   text-transform: capitalize;
 `;
 
-const StyledBadge = styled(Badge)<{ isActive?: boolean }>`
+const StyledBadge = styled(Badge)`
   margin-left: 5px;
   padding: 4px 7px;
-  ${(props) =>
-    props.isActive &&
-    `
-    color: ${color.secondary};
-    background: #E3F3FF;
-  `}
 `;
 
 const syntaxNameMap = {
@@ -49,7 +43,7 @@ export function TabLabel({ isActive, framework, syntax }) {
   return isFrameworkSpecific ? (
     <>
       <CodeSnippetFramework>{framework}</CodeSnippetFramework>
-      <StyledBadge isActive={isActive}>{prettifiedSyntax}</StyledBadge>
+      <StyledBadge status={isActive ? 'selected' : 'neutral'}>{prettifiedSyntax}</StyledBadge>
     </>
   ) : (
     <span>{prettifiedSyntax}</span>

--- a/src/components/screens/DocsScreen/CodeSnippets.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { rgba } from 'polished';
 import { styled } from '@storybook/theming';
-
 import {
   Badge,
   CodeSnippets as DesignSystemCodeSnippets,
@@ -12,7 +12,19 @@ import {
 import { CODE_SNIPPET_CLASSNAME } from '../../../constants/code-snippets';
 import stylizeFramework from '../../../util/stylize-framework';
 
-const { color, typography } = styles;
+const { color, spacing, typography } = styles;
+
+const StyledCodeSnippets = styled(DesignSystemCodeSnippets)`
+  &:target {
+    background: linear-gradient(
+      90deg,
+      ${rgba(color.secondary, 0.1)} 0%,
+      ${rgba(color.secondary, 0.0)} 70%
+    );
+    margin: -${spacing.padding.small}px;
+    padding: ${spacing.padding.small}px;
+  }
+`;
 
 const CodeSnippetFramework = styled.span`
   text-transform: capitalize;
@@ -57,7 +69,7 @@ TabLabel.propTypes = {
 };
 
 export function PureCodeSnippets(props) {
-  return <DesignSystemCodeSnippets className={CODE_SNIPPET_CLASSNAME} {...props} />;
+  return <StyledCodeSnippets className={CODE_SNIPPET_CLASSNAME} {...props} />;
 }
 
 const MissingMessagingWrapper = styled.div`
@@ -95,6 +107,12 @@ export function CodeSnippets({ paths, currentFramework, ...rest }) {
   if (!activeFrameworkPaths.length) {
     defaultFrameworkPaths = paths.filter((path) => path.split('/')[0] === 'react');
   }
+
+  /**
+   * For a path like `web-components/button-story-click-handler-args.js.mdx`,
+   * capture the group `button-story-click-handler-args`
+   */
+  const id = `snippet-${paths[0].match(/^(?:\w+-*)+\/((?:\w+-*)+)/)[1]}`;
 
   useEffect(() => {
     async function fetchModuleComponents() {
@@ -134,7 +152,7 @@ export function CodeSnippets({ paths, currentFramework, ...rest }) {
 
   if (!snippets.length) return null;
 
-  return <PureCodeSnippets snippets={snippets} {...rest} />;
+  return <PureCodeSnippets snippets={snippets} id={id} {...rest} />;
 }
 
 CodeSnippets.propTypes = {


### PR DESCRIPTION
See corresponding `storybook` PR: https://github.com/storybookjs/storybook/pull/20053

**Preview:**
![Screenshot of code snippet banner pointing to upgrade guide and corresponding CSF 2 example](https://user-images.githubusercontent.com/486540/205178561-1234f185-8700-4a9f-9022-f7198947e726.png)

> **Note**: This API (specifically, the `csf2Path` prop) was chosen to allow pointing to different pages for some snippets in the future. While it is unused today (all CSF 2 snippets live on the same page as their CSF 3 versions), that may not be true in the future.

## How to test

If you'd like to see the message in the actual docs, you'll have to run it locally, as the deploy preview is built from the "latest" docs, which do not have the necessary attributes on the CodeSnippets in the docs content.

1. Check out this branch, `kylegach/dx-392-build-csf-2--csf-3-snippet-banner`
1. Run `yarn extract-monorepo-docs add-csf-2-to-3-banner`
1. Run `GATSBY_SKIP_ADDON_PAGES=true yarn start`

That will pull down the updated docs from the `storybook` PR into your local `frontpage` and run the site locally. The local build won't have all of the redirects, so start here to avoid 404s: http://localhost:8000/docs/react/why-storybook.