### PR TITLE
Chore: Prevents 404 with addons

### DIFF
--- a/src/components/screens/DocsScreen/FrameworkSupportTable.tsx
+++ b/src/components/screens/DocsScreen/FrameworkSupportTable.tsx
@@ -21,7 +21,7 @@ export const FrameworkSupportTable = ({ currentFramework, frameworks, featureGro
       return `${monorepoUrlBase}/${repoPath}`;
     }
     // Default is it is an addon (moved into the community or actively maintained)
-    return communityAddons[name] || `${monorepoUrlBase}/addons/${name}`;
+    return communityAddons[name] || `${monorepoUrlBase}/code/addons/${name}`;
   }
 
   return (


### PR DESCRIPTION
With this small pull request, a minor change is implemented to address a 404 with the addons listed in the API section of the official docs resulting from the recent monorepo changes in terms of structuring.

What was done:
- Updated the string to feature in the `code` folder

In the long run, we'll need to start thinking of a better way to address this.

@valentinpalkovic I've added you as a reviewer so that you can get a familiar sense of where the information is pulled in here. I'm going to update the Storybook monorepo and loop you in so that you get the full scope of the required changes.