### PR TITLE
Fix status page redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -92,7 +92,7 @@
 /showcase/*                                 https://storybook-component-catalog.netlify.app/showcase/:splat                                     200
 /tutorials/*                                https://storybook-tutorials.netlify.app/tutorials/:splat                                            200
 /day/*                                      https://storybook-day-2023.netlify.app/day/:splat                                                   200
-/status/*                                   https://storybook-status.netlify.app/:splat                                                         200
+/status/*                                   https://storybook-status.netlify.app/status/:splat                                                  200
 
 /telemetry                                  /docs/6.5/react/configure/telemetry                                                                 301
 


### PR DESCRIPTION
it was supposed to be `/status/:splat` rather than `/:splat`