### PR TITLE
Update CodeSnippets logic

### DIFF
--- a/src/components/screens/DocsScreen/CodeSnippets.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets.tsx
@@ -129,16 +129,24 @@ export function CsfMessage({
   );
 }
 
+function filterPathsByFramework(paths: string[], framework: string) {
+  return paths.filter((path) => {
+    const [pathFramework] = path.split('/');
+    return pathFramework === framework;
+  });
+}
+
 export function CodeSnippets({ csf2Path, currentFramework, paths, usesCsf3, ...rest }) {
   const [snippets, setSnippets] = React.useState([]);
-  const activeFrameworkPaths = paths.filter((path) => {
-    const [framework] = path.split('/');
-    return framework === currentFramework || framework === COMMON;
-  });
+  let activeFrameworkPaths = filterPathsByFramework(paths, currentFramework);
+
+  if (!activeFrameworkPaths.length) {
+    activeFrameworkPaths = filterPathsByFramework(paths, COMMON);
+  }
 
   let defaultFrameworkPaths;
   if (!activeFrameworkPaths.length) {
-    defaultFrameworkPaths = paths.filter((path) => path.split('/')[0] === 'react');
+    defaultFrameworkPaths = filterPathsByFramework(paths, 'react');
   }
 
   /**


### PR DESCRIPTION
- No longer show `common` snippets if non-`common` snippets are available

For this URL, `/docs/web-components/writing-stories/play-function/`, and this instance:

```jsx
<CodeSnippets
  paths={[
    'common/register-component-with-play-function.js.mdx',
    'common/register-component-with-play-function.ts.mdx',
    'web-components/register-component-with-play-function.js.mdx',
    'web-components/register-component-with-play-function.ts.mdx',
  ]}
/>
```

### Before
![](https://user-images.githubusercontent.com/486540/211064614-af5c5b7a-0039-40e6-bfbc-8f61ba52677a.png)

### After
![](https://user-images.githubusercontent.com/486540/211064439-f5c76e2c-06ea-40cb-b29a-2230ce622696.png)

-----

URLs like `/docs/react/writing-stories/play-function/` (i.e. if an exact framework match is unavailable) display the `common` snippets as they did before:

![](https://user-images.githubusercontent.com/486540/211064947-3fc1e7cb-ed76-4f8e-867a-c7af92985bb8.png)

-----

The case where a framework has a match in one language and not another also displays as before. Here, the `react` framework does not match for the `JS` language, so it falls back to `common`. But it _does_ have a match for `TS`, so it uses that directly.

For this URL, `/docs/react/api/csf/`, and this instance:

```jsx
<CodeSnippets
  paths={[
    'common/csf-3-example-starter.js.mdx',
    'web-components/csf-3-example-starter.js.mdx',
    'react/csf-3-example-starter.ts.mdx',
    'vue/csf-3-example-starter.ts-2.ts.mdx',
    'vue/csf-3-example-starter.ts-3.ts.mdx',
    'angular/csf-3-example-starter.ts.mdx',
    'web-components/csf-3-example-starter.ts.mdx',
  ]}
/>
```

![](https://user-images.githubusercontent.com/486540/211096268-393257a7-e0ac-46da-b845-6be9ad21cd02.png)

> Note: Because there is a `web-components` version of the `JS` language snippet, it would display like the **After** screenshot above.
