### PR TITLE
Update recipe and doc layouts for global search indexing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -215,7 +215,7 @@ module.exports = {
             // Generate a sitemap for all pages, all versions, all frameworks
             resolve: `gatsby-plugin-sitemap`,
             options: {
-              output: '/sitemap-all.xml',
+              output: '/sitemap-all',
               query: `
                 {
                   site {

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -278,7 +278,7 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
         <Content>
           {tocSectionTitles && (
             <span hidden id="toc-section-titles">
-              {tocSectionTitles}
+              {`Docs > ${tocSectionTitles}`}
             </span>
           )}
           {(isLatestProp === false || !isLatest) && (

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -278,7 +278,7 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
         <Content>
           {tocSectionTitles && (
             <span hidden id="toc-section-titles">
-              {`Docs > ${tocSectionTitles}`}
+              {`Docs » ${tocSectionTitles}`}
             </span>
           )}
           {(isLatestProp === false || !isLatest) && (

--- a/src/components/layout/integrations/recipes/RecipeItemDetail.js
+++ b/src/components/layout/integrations/recipes/RecipeItemDetail.js
@@ -49,7 +49,7 @@ Image.propTypes = {
   src: PropTypes.string.isRequired,
 };
 
-const Title = styled.div`
+const Title = styled.h1`
   font-weight: ${typography.weight.bold};
   font-size: ${typography.size.l1}px;
   line-height: ${typography.size.l2}px;

--- a/src/components/layout/integrations/recipes/RecipeItemDetail.js
+++ b/src/components/layout/integrations/recipes/RecipeItemDetail.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { css, styled } from '@storybook/theming';
-import { styles, animation } from '@storybook/design-system';
+import { styled } from '@storybook/theming';
+import { styles } from '@storybook/design-system';
 
 import { IntegrationImage } from '../IntegrationImage';
 import emptySVG from '../../../../images/addon-catalog/recipes/recipe-empty.svg';
@@ -104,12 +104,8 @@ export const RecipeItemDetail = ({
       <RecipeInfo>
         <IntegrationImage icon={icon} accent={accentColor} withConnector />
         <div>
-          <Title>
-            <span>{`Integrate ${formattedName} and Storybook`}</span>
-          </Title>
-          <Description>
-            <span>{formattedDescription}</span>
-          </Description>
+          <Title>{`Integrate ${formattedName} and Storybook`}</Title>
+          <Description>{formattedDescription}</Description>
         </div>
       </RecipeInfo>
     </RecipeItemWrapper>

--- a/src/components/layout/integrations/recipes/RecipeItemDetail.js
+++ b/src/components/layout/integrations/recipes/RecipeItemDetail.js
@@ -7,7 +7,6 @@ import { IntegrationImage } from '../IntegrationImage';
 import emptySVG from '../../../../images/addon-catalog/recipes/recipe-empty.svg';
 
 const { color, typography, breakpoint } = styles;
-const { inlineGlow } = animation;
 
 const RecipeItemWrapper = styled.div`
   flex: 1;
@@ -37,15 +36,8 @@ const Image = styled.div`
   background-size: contain;
   background-position: center;
   background-repeat: no-repeat;
-
-  ${(props) =>
-    props.isLoading &&
-    css`
-      ${inlineGlow}
-    `}
 `;
 Image.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
   src: PropTypes.string.isRequired,
 };
 
@@ -68,20 +60,7 @@ const Title = styled.h1`
   span {
     width: 100%;
   }
-
-  ${(props) =>
-    props.isLoading &&
-    css`
-      line-height: ${typography.size.l1}px;
-      span {
-        ${inlineGlow}
-        margin-bottom: 8px;
-      }
-    `}
 `;
-Title.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
-};
 
 const Description = styled.div`
   font-size: ${typography.size.s3}px;
@@ -94,15 +73,6 @@ const Description = styled.div`
   span {
     width: 100%;
   }
-
-  ${(props) =>
-    props.isLoading &&
-    css`
-      line-height: ${typography.size.s3}px;
-      span {
-        ${inlineGlow}
-      }
-    `};
 `;
 
 const RecipeInfo = styled.div`
@@ -120,7 +90,6 @@ export const RecipeItemDetail = ({
   weeklyDownloads,
   appearance,
   status,
-  isLoading,
   verifiedCreator,
   publishedAt,
   npmUrl,
@@ -135,11 +104,11 @@ export const RecipeItemDetail = ({
       <RecipeInfo>
         <IntegrationImage icon={icon} accent={accentColor} withConnector />
         <div>
-          <Title isLoading={isLoading}>
-            <span>{isLoading ? 'loading' : `Integrate ${formattedName} and Storybook`}</span>
+          <Title>
+            <span>{`Integrate ${formattedName} and Storybook`}</span>
           </Title>
-          <Description isLoading={isLoading}>
-            <span>{isLoading ? 'loading description of addon' : formattedDescription}</span>
+          <Description>
+            <span>{formattedDescription}</span>
           </Description>
         </div>
       </RecipeInfo>
@@ -156,7 +125,6 @@ RecipeItemDetail.propTypes = {
   displayName: PropTypes.string,
   description: PropTypes.string,
   weeklyDownloads: PropTypes.number,
-  isLoading: PropTypes.bool,
   verifiedCreator: PropTypes.string,
   publishedAt: PropTypes.number,
   npmUrl: PropTypes.string,
@@ -166,7 +134,6 @@ RecipeItemDetail.defaultProps = {
   appearance: 'community',
   status: 'default',
   weeklyDownloads: 0,
-  isLoading: false,
   name: '',
   description: '',
   verifiedCreator: '',

--- a/src/components/layout/integrations/recipes/RecipeItemDetail.js
+++ b/src/components/layout/integrations/recipes/RecipeItemDetail.js
@@ -41,14 +41,15 @@ Image.propTypes = {
   src: PropTypes.string.isRequired,
 };
 
+const TextContainer = styled.div`
+  text-align: center;
+`;
+
 const Title = styled.h1`
   font-weight: ${typography.weight.bold};
   font-size: ${typography.size.l1}px;
   line-height: ${typography.size.l2}px;
-  text-align: center;
   color: ${color.darkest};
-  display: flex;
-  align-items: center;
   position: relative;
   margin-top: 1rem;
   margin-bottom: 0.75rem;
@@ -56,16 +57,11 @@ const Title = styled.h1`
   @media (min-width: ${1 * breakpoint}px) {
     margin-top: 1.5rem;
   }
-
-  span {
-    width: 100%;
-  }
 `;
 
-const Description = styled.div`
+const Description = styled.p`
   font-size: ${typography.size.s3}px;
   line-height: 28px;
-  text-align: center;
   color: ${color.darkest};
   position: relative;
   max-width: 600px;
@@ -103,10 +99,10 @@ export const RecipeItemDetail = ({
     <RecipeItemWrapper {...props}>
       <RecipeInfo>
         <IntegrationImage icon={icon} accent={accentColor} withConnector />
-        <div>
+        <TextContainer>
           <Title>{`Integrate ${formattedName} and Storybook`}</Title>
           <Description>{formattedDescription}</Description>
-        </div>
+        </TextContainer>
       </RecipeInfo>
     </RecipeItemWrapper>
   );

--- a/src/components/layout/integrations/recipes/RecipeItemDetail.js
+++ b/src/components/layout/integrations/recipes/RecipeItemDetail.js
@@ -65,10 +65,7 @@ const Description = styled.p`
   color: ${color.darkest};
   position: relative;
   max-width: 600px;
-
-  span {
-    width: 100%;
-  }
+  margin: 0;
 `;
 
 const RecipeInfo = styled.div`

--- a/src/components/screens/DocsScreen/DocsSearch.tsx
+++ b/src/components/screens/DocsScreen/DocsSearch.tsx
@@ -142,6 +142,9 @@ export function DocsSearch({ framework, version, visible }: DocsSearchProps) {
             searchParameters={{
               // prettier-ignore
               facetFilters: [
+              // To include recipes in the global doc search
+              // we need to allow for the recipes tag as well
+              // as indexes without a framework or version tied to them
               ['tags:docs', 'tags:recipes'],
               [`framework:${framework}`, 'framework:agnostic'],
               [`version:${version}`, 'version:agnostic'],

--- a/src/components/screens/DocsScreen/DocsSearch.tsx
+++ b/src/components/screens/DocsScreen/DocsSearch.tsx
@@ -142,9 +142,9 @@ export function DocsSearch({ framework, version, visible }: DocsSearchProps) {
             searchParameters={{
               // prettier-ignore
               facetFilters: [
-              'tags:docs',
-              `framework:${framework}`,
-              `version:${version}`
+              ['tags:docs', 'tags:recipes'],
+              [`framework:${framework}`, 'framework:agnostic'],
+              [`version:${version}`, 'version:agnostic'],
             ],
             }}
             translations={{

--- a/src/components/screens/IntegrationsCatalog/RecipesDetailScreen/RecipesDetailScreen.js
+++ b/src/components/screens/IntegrationsCatalog/RecipesDetailScreen/RecipesDetailScreen.js
@@ -256,7 +256,7 @@ export const RecipesDetailScreen = ({ path, location, pageContext }) => {
                 </AddonsCallout>
               </section>
             )}
-            <ReadMeContent>
+            <ReadMeContent id="recipe-content-body">
               <MDXProvider
                 components={{
                   pre: Pre,

--- a/src/components/screens/IntegrationsCatalog/RecipesDetailScreen/RecipesDetailScreen.js
+++ b/src/components/screens/IntegrationsCatalog/RecipesDetailScreen/RecipesDetailScreen.js
@@ -270,7 +270,7 @@ export const RecipesDetailScreen = ({ path, location, pageContext }) => {
               </MDXProvider>
             </ReadMeContent>
           </ReadMe>
-          <IntegrationsAside hideLearn>
+          <IntegrationsAside id="recipe-sidebar" hideLearn>
             {hasAddons && (
               <>
                 <IntegrationsSubheading>On this page</IntegrationsSubheading>


### PR DESCRIPTION
## Why have you done this?
We want to add recipes into the global search which requires some markup changes for Algolia to index them.

## What's changed?
- Use h1 tag for recipe header title
- Remove unused loading state from recipeItemDetail
- Add "Docs > " to hidden algolia indexing title on docs layout
- Change name of directory for sitemap-all