### PR TITLE
Add importance meta to rate docs higher than recipes

### DIFF
--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -24,6 +24,7 @@ import buildPathWithFramework from '../../util/build-path-with-framework';
 import { FrameworkSelector } from '../screens/DocsScreen/FrameworkSelector';
 import { VersionSelector } from '../screens/DocsScreen/VersionSelector';
 import { VersionCTA } from '../screens/DocsScreen/VersionCTA';
+import { GLOBAL_SEARCH_IMPORTANCE, GLOBAL_SEARCH_META_KEYS } from '../../constants/global-search';
 
 const { breakpoint, pageMargins } = styles;
 const { GlobalStyle } = global;
@@ -204,8 +205,21 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
             )}/`}
           />
         )}
-        <meta key="docsearch:framework" name="docsearch:framework" content={framework} />
-        <meta key="docsearch:version" name="docsearch:version" content={versionString} />
+        <meta
+          key={GLOBAL_SEARCH_META_KEYS.FRAMEWORK}
+          name={GLOBAL_SEARCH_META_KEYS.FRAMEWORK}
+          content={framework}
+        />
+        <meta
+          key={GLOBAL_SEARCH_META_KEYS.VERSION}
+          name={GLOBAL_SEARCH_META_KEYS.VERSION}
+          content={versionString}
+        />
+        <meta
+          key={GLOBAL_SEARCH_META_KEYS.IMPORTANCE}
+          name={GLOBAL_SEARCH_META_KEYS.IMPORTANCE}
+          content={GLOBAL_SEARCH_IMPORTANCE.DOCS}
+        />
       </Helmet>
       <SubNav>
         <SubNavTabs label="Docs nav" items={docsItems} />

--- a/src/components/layout/PageLayout.js
+++ b/src/components/layout/PageLayout.js
@@ -121,7 +121,7 @@ export function PurePageLayout({ dxData, children, pageContext, ...props }) {
           <meta
             key={GLOBAL_SEARCH_META_KEYS.IMPORTANCE}
             name={GLOBAL_SEARCH_META_KEYS.IMPORTANCE}
-            content={GLOBAL_SEARCH_IMPORTANCE.RECIPE}
+            content={GLOBAL_SEARCH_IMPORTANCE.AGNOSTIC}
           />
           <link
             rel="preconnect"

--- a/src/components/layout/PageLayout.js
+++ b/src/components/layout/PageLayout.js
@@ -18,6 +18,7 @@ import DocsLayout from './DocsLayout';
 import useSiteMetadata from '../lib/useSiteMetadata';
 
 import { SocialGraph } from '../basics';
+import { GLOBAL_SEARCH_IMPORTANCE, GLOBAL_SEARCH_META_KEYS } from '../../constants/global-search';
 
 const Layout = styled.div``;
 
@@ -107,8 +108,21 @@ export function PurePageLayout({ dxData, children, pageContext, ...props }) {
           {/* 
             Set the docsearch index facets defaults
           */}
-          <meta key="docsearch:framework" name="docsearch:framework" content="agnostic" />
-          <meta key="docsearch:version" name="docsearch:version" content="agnostic" />
+          <meta
+            key={GLOBAL_SEARCH_META_KEYS.FRAMEWORK}
+            name={GLOBAL_SEARCH_META_KEYS.FRAMEWORK}
+            content="agnostic"
+          />
+          <meta
+            key={GLOBAL_SEARCH_META_KEYS.VERSION}
+            name={GLOBAL_SEARCH_META_KEYS.VERSION}
+            content="agnostic"
+          />
+          <meta
+            key={GLOBAL_SEARCH_META_KEYS.IMPORTANCE}
+            name={GLOBAL_SEARCH_META_KEYS.IMPORTANCE}
+            content={GLOBAL_SEARCH_IMPORTANCE.RECIPE}
+          />
           <link
             rel="preconnect"
             href={`https://${algoliaDocSearchConfig.appId}-dsn.algolia.net`}

--- a/src/constants/global-search.js
+++ b/src/constants/global-search.js
@@ -1,0 +1,10 @@
+export const GLOBAL_SEARCH_META_KEYS = {
+  FRAMEWORK: 'docsearch:framework',
+  VERSION: 'docsearch:version',
+  IMPORTANCE: 'docsearch:importance',
+};
+
+export const GLOBAL_SEARCH_IMPORTANCE = {
+  DOCS: 0,
+  RECIPE: 1,
+};

--- a/src/constants/global-search.js
+++ b/src/constants/global-search.js
@@ -6,5 +6,5 @@ export const GLOBAL_SEARCH_META_KEYS = {
 
 export const GLOBAL_SEARCH_IMPORTANCE = {
   DOCS: 0,
-  RECIPE: 1,
+  AGNOSTIC: 1,
 };


### PR DESCRIPTION
Used to tweak cases where recipes are coming up higher than docs when search the name of a framework

The docusearch docs suggest using an integer here so that you can use their sort methods