### PR TITLE
Minor styling tweaks

### DIFF
--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -137,6 +137,10 @@ export const mdFormatting = css`
     &:active {
       transform: translate3d(0, 0, 0);
     }
+
+    code {
+      color: inherit;
+    }
   }
 
   .remark-header-link {


### PR DESCRIPTION
Content styling tweaks to go along with [new API reference pages](https://github.com/storybookjs/storybook/pull/21113).

- ~Add styles for `<h5>`~
- `<code>` inherits color from parent `<a>`

### Before

![image](https://user-images.githubusercontent.com/486540/219276219-87c9855d-7b30-4082-97be-2afec16b1bcc.png)

### After

![image](https://user-images.githubusercontent.com/486540/219276260-9fdb4b56-9eaa-477b-894f-4efffcb4456a.png)
