### PR TITLE
Update various redirects from intro -> install

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -211,9 +211,9 @@ module.exports = {
                 })),
               serialize: ({ url }) => ({ url }),
               // Exclude all doc pages not for React
-              // except the get-started/introduction page for all frameworks
+              // except the first docs page for all frameworks
               excludes: [
-                '{/docs/!(react)/!(get-started)/**,/docs/!(react)/get-started/!(introduction)}',
+                '{/docs/!(react)/!(get-started)/**,/docs/!(react)/get-started/!(install)}',
               ],
             },
           },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,13 +13,17 @@ const sourceDXData = require('./src/util/source-dx-data');
 const { versions } = require('./src/util/versions');
 const createIntegrationsPages = require('./src/util/create-integrations-pages');
 const createHomePage = require('./src/util/create-home-page');
+const siteMetadata = require('./site-metadata');
+
+const {
+  urls: { firstDocsPageSlug },
+} = siteMetadata;
 
 const docsTocWithPaths = addStateToToc(docsToc);
 
 const nextVersionString = versions.preRelease[0].string;
 
 let frameworks;
-const FIRST_DOCS_PAGE_SLUG = '/docs/get-started/introduction';
 
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
@@ -193,7 +197,7 @@ exports.createPages = ({ actions, graphql }) => {
                           nextTocItem.type === 'bullet-link' && {
                             nextTocItem,
                           }),
-                        isIntroPage: slug === FIRST_DOCS_PAGE_SLUG,
+                        isFirstPage: slug === firstDocsPageSlug,
                       },
                     });
                   });
@@ -276,11 +280,11 @@ function updateRedirectsFile() {
 
       acc.push(
         // prettier-ignore
-        `/docs${versionSlug} ${versionBranch}${buildPathWithFramework(FIRST_DOCS_PAGE_SLUG, frameworks[0], versionStringLocal)} ${redirectCode}`
+        `/docs${versionSlug} ${versionBranch}${buildPathWithFramework(firstDocsPageSlug, frameworks[0], versionStringLocal)} ${redirectCode}`
       );
       frameworks.forEach((f) =>
         // prettier-ignore
-        acc.push(`/docs${versionSlug}/${f} ${versionBranch}${buildPathWithFramework(FIRST_DOCS_PAGE_SLUG, f, versionStringLocal)} ${redirectCode}`)
+        acc.push(`/docs${versionSlug}/${f} ${versionBranch}${buildPathWithFramework(firstDocsPageSlug, f, versionStringLocal)} ${redirectCode}`)
       );
 
       if (!isLatestLocal) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,7 +16,7 @@ const createHomePage = require('./src/util/create-home-page');
 const siteMetadata = require('./site-metadata');
 
 const {
-  urls: { firstDocsPageSlug },
+  urls: { installDocsPageSlug },
 } = siteMetadata;
 
 const docsTocWithPaths = addStateToToc(docsToc);
@@ -197,7 +197,7 @@ exports.createPages = ({ actions, graphql }) => {
                           nextTocItem.type === 'bullet-link' && {
                             nextTocItem,
                           }),
-                        isFirstPage: slug === firstDocsPageSlug,
+                        isInstallPage: slug === installDocsPageSlug,
                       },
                     });
                   });
@@ -280,11 +280,11 @@ function updateRedirectsFile() {
 
       acc.push(
         // prettier-ignore
-        `/docs${versionSlug} ${versionBranch}${buildPathWithFramework(firstDocsPageSlug, frameworks[0], versionStringLocal)} ${redirectCode}`
+        `/docs${versionSlug} ${versionBranch}${buildPathWithFramework(installDocsPageSlug, frameworks[0], versionStringLocal)} ${redirectCode}`
       );
       frameworks.forEach((f) =>
         // prettier-ignore
-        acc.push(`/docs${versionSlug}/${f} ${versionBranch}${buildPathWithFramework(firstDocsPageSlug, f, versionStringLocal)} ${redirectCode}`)
+        acc.push(`/docs${versionSlug}/${f} ${versionBranch}${buildPathWithFramework(installDocsPageSlug, f, versionStringLocal)} ${redirectCode}`)
       );
 
       if (!isLatestLocal) {

--- a/site-metadata.js
+++ b/site-metadata.js
@@ -75,6 +75,8 @@ const siteMetadata = {
     telemetry: `/telemetry/`,
     team: `/team/`,
     addonsApi: '/docs/react/addons/addons-api/',
+    // This slug is also used to exclude some pages from the sitemap in gatsby-config.js
+    firstDocsPageSlug: '/docs/get-started/install/',
 
     // Social
     blog: `https://storybook.js.org/blog`,

--- a/site-metadata.js
+++ b/site-metadata.js
@@ -76,7 +76,7 @@ const siteMetadata = {
     team: `/team/`,
     addonsApi: '/docs/react/addons/addons-api/',
     // This slug is also used to exclude some pages from the sitemap in gatsby-config.js
-    firstDocsPageSlug: '/docs/get-started/install/',
+    installDocsPageSlug: '/docs/get-started/install/',
 
     // Social
     blog: `https://storybook.js.org/blog`,

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -202,7 +202,7 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
     latestVersionString,
     isLatest,
   } = useSiteMetadata();
-  const { docsToc, framework, fullPath, slug, versions, isFirstPage } = pageContext;
+  const { docsToc, framework, fullPath, slug, versions, isInstallPage } = pageContext;
 
   const tocSectionTitles = getTocSectionTitles(docsToc, slug.split('/docs/')[1]);
 
@@ -223,7 +223,7 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
 
   // The React specific docs are treated as canonical except for the
   // first docs page for all other frameworks.
-  const canonicalFramework = isFirstPage ? framework : 'react';
+  const canonicalFramework = isInstallPage ? framework : 'react';
 
   return (
     <>
@@ -248,7 +248,7 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
            * https://github.com/storybookjs/components-marketing/blob/e71de9ccc807aee144beff83b947f32996184780/src/components/Search.tsx#L170
            *
            */
-          content={isFirstPage ? GLOBAL_SEARCH_AGNOSTIC : framework}
+          content={isInstallPage ? GLOBAL_SEARCH_AGNOSTIC : framework}
         />
         <meta
           key={GLOBAL_SEARCH_META_KEYS.VERSION}

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -198,7 +198,7 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
     latestVersionString,
     isLatest,
   } = useSiteMetadata();
-  const { docsToc, framework, fullPath, slug, versions } = pageContext;
+  const { docsToc, framework, fullPath, slug, versions, isFirstPage } = pageContext;
 
   const tocSectionTitles = getTocSectionTitles(docsToc, slug.split('/docs/')[1]);
 
@@ -218,8 +218,8 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
   };
 
   // The React specific docs are treated as canonical except for the
-  // docs home page for all other frameworks.
-  const canonicalFramework = slug === '/docs/get-started/introduction' ? framework : 'react';
+  // first docs page for all other frameworks.
+  const canonicalFramework = isFirstPage ? framework : 'react';
 
   return (
     <>

--- a/src/components/layout/DocsLayout.js
+++ b/src/components/layout/DocsLayout.js
@@ -24,7 +24,11 @@ import buildPathWithFramework from '../../util/build-path-with-framework';
 import { FrameworkSelector } from '../screens/DocsScreen/FrameworkSelector';
 import { VersionSelector } from '../screens/DocsScreen/VersionSelector';
 import { VersionCTA } from '../screens/DocsScreen/VersionCTA';
-import { GLOBAL_SEARCH_IMPORTANCE, GLOBAL_SEARCH_META_KEYS } from '../../constants/global-search';
+import {
+  GLOBAL_SEARCH_AGNOSTIC,
+  GLOBAL_SEARCH_IMPORTANCE,
+  GLOBAL_SEARCH_META_KEYS,
+} from '../../constants/global-search';
 
 const { breakpoint, color, pageMargins, typography } = styles;
 const { GlobalStyle } = global;
@@ -238,7 +242,13 @@ function DocsLayout({ children, isLatest: isLatestProp, pageContext }) {
         <meta
           key={GLOBAL_SEARCH_META_KEYS.FRAMEWORK}
           name={GLOBAL_SEARCH_META_KEYS.FRAMEWORK}
-          content={framework}
+          /*
+           * Using `GLOBAL_SEARCH_AGNOSTIC` as the framework value for the first page of the docs
+           * to ensure it shows in search results regardless of current framework
+           * https://github.com/storybookjs/components-marketing/blob/e71de9ccc807aee144beff83b947f32996184780/src/components/Search.tsx#L170
+           *
+           */
+          content={isFirstPage ? GLOBAL_SEARCH_AGNOSTIC : framework}
         />
         <meta
           key={GLOBAL_SEARCH_META_KEYS.VERSION}

--- a/src/components/layout/DocsLayout.stories.js
+++ b/src/components/layout/DocsLayout.stories.js
@@ -24,8 +24,8 @@ export const pageContext = {
   framework: 'react',
   docsToc: docsTocWithPathsAndFramework,
   tocItem: { ...docsTocWithPaths[1].children[0], githubUrl: undefined },
-  fullPath: '/docs/react/get-started/introduction',
-  slug: '/docs/get-started/introduction',
+  fullPath: '/docs/react/get-started/install',
+  slug: '/docs/get-started/install',
   versions,
 };
 

--- a/src/components/layout/PageLayout.js
+++ b/src/components/layout/PageLayout.js
@@ -18,7 +18,11 @@ import DocsLayout from './DocsLayout';
 import useSiteMetadata from '../lib/useSiteMetadata';
 
 import { SocialGraph } from '../basics';
-import { GLOBAL_SEARCH_IMPORTANCE, GLOBAL_SEARCH_META_KEYS } from '../../constants/global-search';
+import {
+  GLOBAL_SEARCH_AGNOSTIC,
+  GLOBAL_SEARCH_IMPORTANCE,
+  GLOBAL_SEARCH_META_KEYS,
+} from '../../constants/global-search';
 
 const Layout = styled.div``;
 
@@ -111,12 +115,12 @@ export function PurePageLayout({ dxData, children, pageContext, ...props }) {
           <meta
             key={GLOBAL_SEARCH_META_KEYS.FRAMEWORK}
             name={GLOBAL_SEARCH_META_KEYS.FRAMEWORK}
-            content="agnostic"
+            content={GLOBAL_SEARCH_AGNOSTIC}
           />
           <meta
             key={GLOBAL_SEARCH_META_KEYS.VERSION}
             name={GLOBAL_SEARCH_META_KEYS.VERSION}
-            content="agnostic"
+            content={GLOBAL_SEARCH_AGNOSTIC}
           />
           <meta
             key={GLOBAL_SEARCH_META_KEYS.IMPORTANCE}

--- a/src/components/layout/PageLayout.js
+++ b/src/components/layout/PageLayout.js
@@ -31,7 +31,7 @@ const ALGOLIA_API_KEY = process.env.GATSBY_ALGOLIA_API_KEY;
 const navLinks = {
   ...defaultLinks,
   home: { url: '/', linkWrapper: GatsbyLinkWrapper },
-  whyStorybook: { url: '/docs/react/why-storybook', linkWrapper: GatsbyLinkWrapper },
+  whyStorybook: { url: '/docs/react/get-started/why-storybook', linkWrapper: GatsbyLinkWrapper },
   guides: { url: '/docs', linkWrapper: GatsbyLinkWrapper },
   changelog: { url: '/releases', linkWrapper: GatsbyLinkWrapper },
   telemetry: { url: '/telemetry/', linkWrapper: GatsbyLinkWrapper },

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -84,7 +84,7 @@ function DocsScreen({ data, pageContext, location }) {
     featureGroups,
     urls: { homepageUrl },
   } = useSiteMetadata();
-  const { framework, docsToc, fullPath, slug, tocItem, nextTocItem, isFirstPage } = pageContext;
+  const { framework, docsToc, fullPath, slug, tocItem, nextTocItem, isInstallPage } = pageContext;
   const CodeSnippetsWithCurrentFramework = useMemo(() => {
     return (props) => <CodeSnippets currentFramework={framework} {...props} />;
   }, [framework]);
@@ -146,7 +146,7 @@ function DocsScreen({ data, pageContext, location }) {
       <SocialGraph url={`${homepageUrl}${fullPath}/`} title={title} desc={description} />
 
       <MDWrapper>
-        <Title>{isFirstPage ? `${title} for ${stylizeFramework(framework)}` : title}</Title>
+        <Title>{isInstallPage ? `${title} for ${stylizeFramework(framework)}` : title}</Title>
         {unsupported && (
           <UnsupportedBanner>
             This feature is not supported in {stylizeFramework(framework)} yet. Help the open source

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -84,7 +84,7 @@ function DocsScreen({ data, pageContext, location }) {
     featureGroups,
     urls: { homepageUrl },
   } = useSiteMetadata();
-  const { framework, docsToc, fullPath, slug, tocItem, nextTocItem, isIntroPage } = pageContext;
+  const { framework, docsToc, fullPath, slug, tocItem, nextTocItem, isFirstPage } = pageContext;
   const CodeSnippetsWithCurrentFramework = useMemo(() => {
     return (props) => <CodeSnippets currentFramework={framework} {...props} />;
   }, [framework]);
@@ -146,7 +146,7 @@ function DocsScreen({ data, pageContext, location }) {
       <SocialGraph url={`${homepageUrl}${fullPath}/`} title={title} desc={description} />
 
       <MDWrapper>
-        <Title>{isIntroPage ? `${title} for ${stylizeFramework(framework)}` : title}</Title>
+        <Title>{isFirstPage ? `${title} for ${stylizeFramework(framework)}` : title}</Title>
         {unsupported && (
           <UnsupportedBanner>
             This feature is not supported in {stylizeFramework(framework)} yet. Help the open source

--- a/src/components/screens/DocsScreen/FrameworkSelector.stories.tsx
+++ b/src/components/screens/DocsScreen/FrameworkSelector.stories.tsx
@@ -27,7 +27,7 @@ Base.args = {
   framework: coreFrameworks[0],
   coreFrameworks,
   communityFrameworks,
-  slug: '/docs/get-started/introduction',
+  slug: '/docs/get-started/install',
 };
 Base.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);

--- a/src/components/screens/DocsScreen/VersionCTA.stories.tsx
+++ b/src/components/screens/DocsScreen/VersionCTA.stories.tsx
@@ -26,7 +26,7 @@ OldVersion.args = {
   latestVersion: versions.stable[0].version,
   latestVersionString: versions.stable[0].string,
   versions,
-  slug: '/docs/get-started/introduction',
+  slug: '/docs/get-started/install',
 };
 
 export const PreReleaseVersion = Template.bind({});

--- a/src/components/screens/DocsScreen/VersionSelector.stories.tsx
+++ b/src/components/screens/DocsScreen/VersionSelector.stories.tsx
@@ -28,7 +28,7 @@ Base.args = {
   version: versions.stable[0].version,
   versions,
   framework: coreFrameworks[0],
-  slug: '/docs/get-started/introduction',
+  slug: '/docs/get-started/install',
 };
 Base.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);

--- a/src/components/screens/IndexScreen/Develop.js
+++ b/src/components/screens/IndexScreen/Develop.js
@@ -254,7 +254,7 @@ export function Develop({ docs, startOpen, ...props }) {
               <Link
                 containsIcon
                 withArrow
-                href="/docs/react/why-storybook"
+                href="/docs/react/get-started/why-storybook"
                 LinkWrapper={GatsbyLinkWrapper}
               >
                 Why build UIs in isolation?
@@ -311,7 +311,7 @@ export function Develop({ docs, startOpen, ...props }) {
               <Link
                 containsIcon
                 withArrow
-                href="/docs/react/why-storybook"
+                href="/docs/react/get-started/why-storybook"
                 LinkWrapper={GatsbyLinkWrapper}
               >
                 Why build UIs in isolation?

--- a/src/components/screens/IndexScreen/Develop.js
+++ b/src/components/screens/IndexScreen/Develop.js
@@ -19,7 +19,7 @@ import { ScrollDemo } from './StorybookDemo/ScrollDemo';
 import buildPathWithFramework from '../../../util/build-path-with-framework';
 
 const {
-  urls: { firstDocsPageSlug },
+  urls: { installDocsPageSlug },
 } = siteMetadata;
 
 const { subheading, breakpoints, pageMargins } = styles;
@@ -44,7 +44,7 @@ const frameworkIntegrations = featuredFrameworks.map((framework) => ({
   image: `/frameworks/logo-${
     framework === 'web-components' ? 'web-components-alt' : framework
   }.svg`,
-  href: buildPathWithFramework(firstDocsPageSlug, framework),
+  href: buildPathWithFramework(installDocsPageSlug, framework),
   ButtonWrapper: GatsbyLinkWrapper,
 }));
 

--- a/src/components/screens/IndexScreen/Develop.js
+++ b/src/components/screens/IndexScreen/Develop.js
@@ -10,11 +10,17 @@ import {
   Testimonial,
 } from '@storybook/components-marketing';
 import { useScroll, useTransform, useSpring, motion } from 'framer-motion';
+import siteMetadata from '../../../../site-metadata';
 import GatsbyLinkWrapper from '../../basics/GatsbyLinkWrapper';
 import { Stat } from '../../basics/Stat';
 import AtomicDesignLogoSVG from '../../../images/logos/user/logo-atomicdesign.svg';
 import { Integrations } from './Integrations';
 import { ScrollDemo } from './StorybookDemo/ScrollDemo';
+import buildPathWithFramework from '../../../util/build-path-with-framework';
+
+const {
+  urls: { firstDocsPageSlug },
+} = siteMetadata;
 
 const { subheading, breakpoints, pageMargins } = styles;
 
@@ -38,7 +44,7 @@ const frameworkIntegrations = featuredFrameworks.map((framework) => ({
   image: `/frameworks/logo-${
     framework === 'web-components' ? 'web-components-alt' : framework
   }.svg`,
-  href: `/docs/${framework}/get-started/introduction`,
+  href: buildPathWithFramework(firstDocsPageSlug, framework),
   ButtonWrapper: GatsbyLinkWrapper,
 }));
 

--- a/src/constants/global-search.js
+++ b/src/constants/global-search.js
@@ -4,6 +4,8 @@ export const GLOBAL_SEARCH_META_KEYS = {
   IMPORTANCE: 'docsearch:importance',
 };
 
+export const GLOBAL_SEARCH_AGNOSTIC = 'agnostic';
+
 export const GLOBAL_SEARCH_IMPORTANCE = {
   DOCS: 0,
   AGNOSTIC: 1,

--- a/src/util/redirects-raw.txt
+++ b/src/util/redirects-raw.txt
@@ -1,3 +1,4 @@
+/docs/why-storybook/                             /docs/get-started/why-storybook                                                301
 /docs/get-started/introduction                   /docs/get-started/install                                                      301
 /docs/workflows/testing-with-storybook/          /docs/writing-tests/introduction/                                              301
 /docs/workflows/unit-testing/                    /docs/writing-tests/importing-stories-in-tests/                                301

--- a/src/util/redirects-raw.txt
+++ b/src/util/redirects-raw.txt
@@ -1,3 +1,4 @@
+/docs/get-started/introduction                   /docs/get-started/install                                                      301
 /docs/workflows/testing-with-storybook/          /docs/writing-tests/introduction/                                              301
 /docs/workflows/unit-testing/                    /docs/writing-tests/importing-stories-in-tests/                                301
 /docs/workflows/visual-testing/                  /docs/writing-tests/visual-testing/                                            301

--- a/static/_redirects
+++ b/static/_redirects
@@ -29,7 +29,7 @@
 /testing/*                                  /docs/testing/:splat                                                                                301
 
 # Pre 6.0 URLs
-/docs/basics/introduction/                  /docs/react/get-started/introduction/                                                               301
+/docs/basics/introduction/                  /docs/react/get-started/install/                                                               301
 /docs/basics/writing-stories/               /docs/react/get-started/whats-a-story/                                                              301
 /docs/basics/exporting-storybook/           /docs/react/workflows/publish-storybook/                                                            301
 /docs/basics/faq/                           /docs/react/workflows/faq/                                                                          301


### PR DESCRIPTION
- Update redirects
    Old:
    - `/docs` → `/docs/react/get-started/introduction`
    - `/docs/<version>` → `/docs/<version>/react/get-started/introduction`
    - `/docs/<version>/<framework>` → `/docs/<version>/<framework>/get-started/introduction`
    New:
    - `/docs` → `/docs/react/get-started/install`
    - `/docs/<version>` → `/docs/<version>/react/get-started/install`
    - `/docs/<version>/<framework>` → `/docs/<version>/<framework>/get-started/install`
- Store `/docs/get-started/install` slug in site-metadata
- Make install docs page always searchable
    - Search is faceted on the current framework
    - This change ensures that each framework's install docs page is searchable, regardless of current framework
- Update misc stories
    - To use `/docs/get-started/install` instead of `/docs/get-started/introduction`
- Add redirect for `/docs/why-storybook`
    - `/docs/why-storybook` -> `/docs/get-started/why-storybook`
    - Update various links to old URL

_See related `storybook` PR: https://github.com/storybookjs/storybook/pull/21393_