### PR TITLE
Fix docs anchor links

### DIFF
--- a/src/components/screens/DocsScreen/CodeSnippets.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets.tsx
@@ -377,7 +377,6 @@ export function CodeSnippets({
 
 CodeSnippets.propTypes = {
   currentFramework: PropTypes.string.isRequired,
-  currentPath: PropTypes.string.isRequired,
   csf2Path: PropTypes.string,
   paths: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   usesCsf3: PropTypes.bool,

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -70,6 +70,29 @@ const UnsupportedBanner = styled.div`
   padding: 20px;
 `;
 
+/*
+ * Checks for an element at a given interval and runs callback, if found.
+ * If not found by given timeout, runs callback anyway.
+ */
+function waitForElementToDisplay(selector, callback, checkFrequencyInMs, timeoutInMs) {
+  const startTimeInMs = Date.now();
+  (function loopSearch(shouldContinue = true) {
+    if (!shouldContinue) return;
+    if (document.querySelector(selector) != null) {
+      callback();
+    } else {
+      setTimeout(() => {
+        if (timeoutInMs && Date.now() - startTimeInMs > timeoutInMs) {
+          callback();
+          loopSearch(false);
+          return;
+        }
+        loopSearch();
+      }, checkFrequencyInMs);
+    }
+  })();
+}
+
 function DocsScreen({ data, pageContext, location }) {
   const {
     currentPage: {
@@ -147,6 +170,22 @@ function DocsScreen({ data, pageContext, location }) {
       }
     });
   findFeatureSupportTocItem(docsToc);
+
+  const { href, hash } = location;
+  React.useEffect(() => {
+    if (hash) {
+      // Wait for whichever happens first: the first snippet on the page to render or 500ms
+      waitForElementToDisplay(
+        '[id^=snippet]',
+        () => {
+          const element = document.querySelector(hash);
+          element?.scrollIntoView();
+        },
+        50,
+        500
+      );
+    }
+  }, [href, hash]);
 
   return (
     <>


### PR DESCRIPTION
## What I did

Prior to this change, links to a heading's anchor would often "miss", due to the dynamic snippet loading. This change checks for all snippets to load, then imperatively scrolls to the desired element.

## How to test

1. Open this page of the deploy preview
    - https://deploy-preview-503--storybook-frontpage.netlify.app/docs/react/writing-stories/args#mapping-to-complex-arg-values
2. Confirm that the page doesn't jump around as it loads
    - i.e. That the highlighted target heading stays near the top of viewport