### PR TITLE
Chore: (Recipes) Removes deprecate reference to stories.mdx

### DIFF
--- a/src/content/recipes/@mui/material.md
+++ b/src/content/recipes/@mui/material.md
@@ -193,7 +193,7 @@ This is because Storybook only adds props to the controls table that are explici
 // .storybook/main.ts
 
 module.exports = {
-  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',


### PR DESCRIPTION
With this small pull request the deprecated reference to `.stories.mdx` is removed from the material ui recipe as we're no longer documenting usage in our documentation nor providing it as a configuration option.

@Integrayshaun, if you're ok with it, merge this after 7.0 lands as to avoid confusion. 

Thanks in advance