### PR TITLE
update headers for iframe release page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,15 @@
   functions = "/functions"
 
 [[headers]]
+  for = "/releases/iframe/*"
+  [headers.values]
+    Content-Security-Policy = "frame-ancestors *"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = ""
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+
+[[headers]]
   for = "/*"
   [headers.values]
     Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.segment.io www.google-analytics.com www.googletagmanager.com *.netlify.app data: platform.twitter.com hcaptcha.com *.hcaptcha.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com hcaptcha.com *.hcaptcha.com; img-src * data:; font-src 'self' fonts.gstatic.com; connect-src 'self' *.segment.io www.google-analytics.com *.netlify.app *.algolia.net api.github.com webmention.io hcaptcha.com *.hcaptcha.com storybook.us18.list-manage.com; frame-src app.netlify.com *.widgetbot.io *.youtube.com *.youtube-nocookie.com platform.twitter.com upscri.be hcaptcha.com *.hcaptcha.com *.chromatic.com; media-src * data:;"


### PR DESCRIPTION
Fixes: https://github.com/storybookjs/storybook/issues/21324

I have added two header sections, defining the security headers to be added to HTTP responses.
The first section specifies headers for requests matching the /releases/iframe/* pattern which allows iFrame embed for all domains, while the second section applies to all other requests with the default policy. 