### PR TITLE
re-tested & fixed headers for release page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,7 +15,3 @@
   for = "/releases/iframe/*"
   [headers.values]
     Content-Security-Policy = "frame-ancestors *"
-    Referrer-Policy = "strict-origin-when-cross-origin"
-    Permissions-Policy = ""
-    X-Content-Type-Options = "nosniff"
-    X-XSS-Protection = "1; mode=block"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,20 +3,19 @@
   functions = "/functions"
 
 [[headers]]
-  for = "/releases/iframe/*"
+  for = "/*"
   [headers.values]
-    Content-Security-Policy = "frame-ancestors *"
+    Content-Security-Policy = "default-src 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.segment.io www.google-analytics.com www.googletagmanager.com *.netlify.app data: platform.twitter.com hcaptcha.com *.hcaptcha.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com hcaptcha.com *.hcaptcha.com; img-src * data:; font-src 'self' fonts.gstatic.com; connect-src 'self' *.segment.io www.google-analytics.com *.netlify.app *.algolia.net api.github.com webmention.io hcaptcha.com *.hcaptcha.com storybook.us18.list-manage.com; frame-src app.netlify.com *.widgetbot.io *.youtube.com *.youtube-nocookie.com platform.twitter.com upscri.be hcaptcha.com *.hcaptcha.com *.chromatic.com; media-src * data:;"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = ""
     X-Content-Type-Options = "nosniff"
     X-XSS-Protection = "1; mode=block"
 
 [[headers]]
-  for = "/*"
+  for = "/releases/iframe/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.segment.io www.google-analytics.com www.googletagmanager.com *.netlify.app data: platform.twitter.com hcaptcha.com *.hcaptcha.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com hcaptcha.com *.hcaptcha.com; img-src * data:; font-src 'self' fonts.gstatic.com; connect-src 'self' *.segment.io www.google-analytics.com *.netlify.app *.algolia.net api.github.com webmention.io hcaptcha.com *.hcaptcha.com storybook.us18.list-manage.com; frame-src app.netlify.com *.widgetbot.io *.youtube.com *.youtube-nocookie.com platform.twitter.com upscri.be hcaptcha.com *.hcaptcha.com *.chromatic.com; media-src * data:;"
+    Content-Security-Policy = "frame-ancestors *"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = ""
     X-Content-Type-Options = "nosniff"
-    X-Frame-Options = "SAMEORIGIN"
     X-XSS-Protection = "1; mode=block"


### PR DESCRIPTION
Fixes: https://github.com/storybookjs/storybook/issues/21324

Related: https://github.com/storybookjs/frontpage/pull/508

The last PR didn't fix the iFrame issue. I forgot to maintain the order of the headers config resulting in "/*" overriding the previous headers config.
Also removed obsolete X-Frame-Options and used "frame-ancestors 'self';" instead.
 REF: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#:~:text=This%20is%20an-,obsolete%20directive,-that%20no%20lonZger
