### PR TITLE
Allow no "next" docs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -21,7 +21,7 @@ const {
 
 const docsTocWithPaths = addStateToToc(docsToc);
 
-const nextVersionString = versions.preRelease[0].string;
+const nextVersionString = versions.preRelease[0]?.string;
 
 let frameworks;
 
@@ -270,7 +270,8 @@ function updateRedirectsFile() {
   const versionRedirects = [...versions.stable, ...versions.preRelease, { string: 'next' }]
     .reduce((acc, { string }) => {
       const isLatestLocal = string === latestVersionString;
-      const versionStringLocal = string === 'next' ? nextVersionString : string;
+      const versionStringLocal =
+        string === 'next' ? nextVersionString || latestVersionString : string;
       const versionSlug = isLatestLocal ? '' : `/${string}`;
       const versionBranch = isLatestLocal ? '' : getReleaseBranchUrl(versionStringLocal);
       const redirectCode = isLatestLocal ? 301 : 200;

--- a/src/components/screens/DocsScreen/VersionSelector.tsx
+++ b/src/components/screens/DocsScreen/VersionSelector.tsx
@@ -44,11 +44,13 @@ export function VersionSelector({ framework, version, versions, slug }: VersionS
       label: 'stable',
       items: stableLinks,
     },
-    {
+  ];
+  if (preReleaseLinks.length > 0) {
+    versionOptions.push({
       label: 'pre-release',
       items: preReleaseLinks,
-    },
-  ];
+    });
+  }
 
   const activeVersion = stylizeVersion(
     [...versions.stable, ...versions.preRelease].find(({ version: v }) => v === version)


### PR DESCRIPTION
- Fix `/docs/next/...` redirect - If "next" version is available, redirect to that - Otherwise, redirect to "latest" version
- Don't render "Prerelease" section of VersionSelector menu if empty