### PR TITLE
Remove skip on v7 tests for CodeSnippets

### DIFF
--- a/src/components/screens/DocsScreen/CodeSnippets.test.ts
+++ b/src/components/screens/DocsScreen/CodeSnippets.test.ts
@@ -50,8 +50,7 @@ it('Selects from available frameworks and languages, TS selected', () => {
   `);
 });
 
-// Un-skip once v7 is "latest"
-describe.skip('v7+', () => {
+describe('v7+', () => {
   it('Selects from available frameworks and languages, TS 4.9 selected', () => {
     const result = getResolvedPaths(
       [


### PR DESCRIPTION
If I understood correctly the comments left by @kylegach, tests were meant to not be skipped once v7 was tagged as latest.

Tests all passed when I checked.