### PR TITLE
Add docs feedback widget

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.segment.io www.google-analytics.com www.googletagmanager.com *.netlify.app data: platform.twitter.com hcaptcha.com *.hcaptcha.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com hcaptcha.com *.hcaptcha.com; img-src * data:; font-src 'self' fonts.gstatic.com; connect-src 'self' *.segment.io www.google-analytics.com *.netlify.app *.algolia.net api.github.com webmention.io hcaptcha.com *.hcaptcha.com storybook.us18.list-manage.com; frame-src app.netlify.com *.widgetbot.io *.youtube.com *.youtube-nocookie.com platform.twitter.com upscri.be hcaptcha.com *.hcaptcha.com *.chromatic.com; media-src * data:;"
+    Content-Security-Policy = "default-src 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.segment.io www.google-analytics.com www.googletagmanager.com *.netlify.app data: platform.twitter.com hcaptcha.com *.hcaptcha.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com hcaptcha.com *.hcaptcha.com; img-src * data:; font-src 'self' fonts.gstatic.com; connect-src 'self' *.segment.io www.google-analytics.com *.netlify.app *.algolia.net api.github.com webmention.io hcaptcha.com *.hcaptcha.com storybook.us18.list-manage.com www.cloudflare.com/cdn-cgi/trace; frame-src app.netlify.com *.widgetbot.io *.youtube.com *.youtube-nocookie.com platform.twitter.com upscri.be hcaptcha.com *.hcaptcha.com *.chromatic.com; media-src * data:;"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = ""
     X-Content-Type-Options = "nosniff"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.segment.io www.google-analytics.com www.googletagmanager.com *.netlify.app data: platform.twitter.com hcaptcha.com *.hcaptcha.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com hcaptcha.com *.hcaptcha.com; img-src * data:; font-src 'self' fonts.gstatic.com; connect-src 'self' *.segment.io www.google-analytics.com *.netlify.app *.algolia.net api.github.com webmention.io hcaptcha.com *.hcaptcha.com storybook.us18.list-manage.com www.cloudflare.com/cdn-cgi/trace; frame-src app.netlify.com *.widgetbot.io *.youtube.com *.youtube-nocookie.com platform.twitter.com upscri.be hcaptcha.com *.hcaptcha.com *.chromatic.com; media-src * data:;"
+    Content-Security-Policy = "default-src 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.segment.io www.google-analytics.com www.googletagmanager.com *.netlify.app data: platform.twitter.com hcaptcha.com *.hcaptcha.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com hcaptcha.com *.hcaptcha.com; img-src * data:; font-src 'self' fonts.gstatic.com; connect-src 'self' *.segment.io www.google-analytics.com *.netlify.app *.algolia.net api.github.com webmention.io hcaptcha.com *.hcaptcha.com storybook.us18.list-manage.com; frame-src app.netlify.com *.widgetbot.io *.youtube.com *.youtube-nocookie.com platform.twitter.com upscri.be hcaptcha.com *.hcaptcha.com *.chromatic.com; media-src * data:;"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = ""
     X-Content-Type-Options = "nosniff"

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -70,8 +70,7 @@ const Contribute = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  align-items: center;
-  gap: ${spacing.padding.large}px;
+  align-items: baseline;
   margin-top: 3rem;
 `;
 

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -23,6 +23,7 @@ import relativeToRootLinks from '../../../util/relative-to-root-links';
 import stylizeFramework from '../../../util/stylize-framework';
 import { useDocsContext } from './DocsContext';
 import { FeatureSnippets } from './FeatureSnippets';
+import { Feedback } from './Feedback';
 import { YouTubeCallout } from './YouTubeCallout';
 
 const { color, spacing, typography } = styles;
@@ -53,11 +54,6 @@ const NextNavigation = styled.div`
   margin-top: 3rem;
 `;
 
-const GithubLinkWrapper = styled.div`
-  margin-top: 3rem;
-  text-align: center;
-`;
-
 const GithubLinkItem = styled(Link)`
   font-weight: ${typography.weight.bold};
   font-size: ${typography.size.s2}px;
@@ -68,6 +64,15 @@ const UnsupportedBanner = styled.div`
   border-radius: ${spacing.borderRadius.small}px;
   background-color: #fff5cf;
   padding: 20px;
+`;
+
+const Contribute = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${spacing.padding.large}px;
+  margin-top: 3rem;
 `;
 
 /*
@@ -115,6 +120,7 @@ function DocsScreen({ data, pageContext, location }) {
     description,
     featureGroups,
     urls: { homepageUrl },
+    versionString,
   } = useSiteMetadata();
   const { framework, docsToc, fullPath, slug, tocItem, nextTocItem, isInstallPage } = pageContext;
 
@@ -264,16 +270,25 @@ function DocsScreen({ data, pageContext, location }) {
         </NextNavigation>
       )}
 
-      {tocItem && tocItem.githubUrl && (
-        <GithubLinkWrapper>
+      <Contribute>
+        {tocItem && (
+          <Feedback
+            key={fullPath}
+            path={fullPath}
+            version={versionString}
+            framework={framework}
+            codeLanguage={codeLanguage}
+          />
+        )}
+        {tocItem && tocItem.githubUrl && (
           <GithubLinkItem tertiary href={tocItem.githubUrl} target="_blank" rel="noopener">
             <span role="img" aria-label="write">
               ✍️
             </span>{' '}
             Edit on GitHub – PRs welcome!
           </GithubLinkItem>
-        </GithubLinkWrapper>
-      )}
+        )}
+      </Contribute>
     </>
   );
 }

--- a/src/components/screens/DocsScreen/Feedback.stories.tsx
+++ b/src/components/screens/DocsScreen/Feedback.stories.tsx
@@ -5,6 +5,7 @@ import { Feedback } from './Feedback';
 type FeedbackProps = React.ComponentProps<typeof Feedback> & {
   forceRating?: 'up' | 'down';
   forceResultUrl?: string;
+  forceError?: string;
 };
 
 // To ensure Chromatic can snapshot correctly
@@ -40,4 +41,9 @@ export const Done = Template.bind({});
 Done.args = {
   forceResultUrl:
     'https://github.com/storybookjs/storybook/discussions/categories/documentation-feedback',
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  forceError: 'Forced error',
 };

--- a/src/components/screens/DocsScreen/Feedback.stories.tsx
+++ b/src/components/screens/DocsScreen/Feedback.stories.tsx
@@ -35,10 +35,9 @@ export const Rated = Template.bind({});
 Rated.args = {
   forceRating: 'up',
 };
-Rated.parameters = { height: '320px' };
 
 export const Done = Template.bind({});
 Done.args = {
-  forceResultUrl: 'https://example.com',
+  forceResultUrl:
+    'https://github.com/storybookjs/storybook/discussions/categories/documentation-feedback',
 };
-Done.parameters = { height: '150px' };

--- a/src/components/screens/DocsScreen/Feedback.stories.tsx
+++ b/src/components/screens/DocsScreen/Feedback.stories.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { Feedback } from './Feedback';
+
+type FeedbackProps = React.ComponentProps<typeof Feedback> & {
+  forceRating?: 'up' | 'down';
+  forceResultUrl?: string;
+};
+
+// To ensure Chromatic can snapshot correctly
+const withHeight = (StoryFn, { parameters: { height } }) =>
+  height ? (
+    <div style={{ height }}>
+      <StoryFn />
+    </div>
+  ) : (
+    <StoryFn />
+  );
+
+const meta: Meta<FeedbackProps> = {
+  title: 'Screens/DocsScreen/Feedback',
+  component: Feedback,
+  decorators: [
+    // @ts-expect-error - It doesn't like the custom parameter
+    withHeight,
+  ],
+};
+export default meta;
+
+const Template: Story<FeedbackProps> = (args) => <Feedback {...args} />;
+
+export const Default = Template.bind({});
+
+export const Rated = Template.bind({});
+Rated.args = {
+  forceRating: 'up',
+};
+Rated.parameters = { height: '320px' };
+
+export const Done = Template.bind({});
+Done.args = {
+  forceResultUrl: 'https://example.com',
+};
+Done.parameters = { height: '150px' };

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { styled, css } from '@storybook/theming';
-import { Button, Link, styles } from '@storybook/design-system';
+import { styled } from '@storybook/theming';
+import { Button, Link, OutlineCTA, styles } from '@storybook/design-system';
 
 const { code, color, spacing, typography } = styles;
 
 const DOCS_FEEDBACK_URL = '/.netlify/functions/docs-feedback';
+const DISCUSSIONS_URL =
+  'https://github.com/storybookjs/storybook/discussions/categories/documentation-feedback';
 
 const heightTransitionTime = 100; // ms
 
@@ -65,7 +67,7 @@ const CommentForm = styled('form', {
 
   overflow: hidden;
   transition: height ${heightTransitionTime}ms ease-out;
-  height: ${(props) => (props.isExpanded ? `${250 / 16}rem` : 0)};
+  height: ${(props) => (props.isExpanded ? `${260 / 16}rem` : 0)};
 `;
 
 const Label = styled.label`
@@ -79,6 +81,7 @@ const HelpText = styled.p`
 
   code {
     ${code.small}
+    color: ${color.dark};
     font-size: inherit;
   }
 `;
@@ -158,22 +161,25 @@ export const Feedback = ({
   const form = (
     <CommentForm ref={formRef} isExpanded={rating || resultUrl} onSubmit={handleSubmit}>
       {resultUrl ? (
-        <>
-          <Prompt>Thanks for your feedback!</Prompt>
-          {resultUrl && (
-            <p>
-              <Link href={resultUrl} target="_blank">
-                View your comment on GitHub
-              </Link>
-            </p>
-          )}
-        </>
+        <OutlineCTA
+          action={
+            <Link href={resultUrl} target="_blank" withArrow>
+              View your comment on GitHub
+            </Link>
+          }
+        >
+          Thanks for your feedback!
+        </OutlineCTA>
       ) : (
         <>
           <Label htmlFor="feedback-comment">Optional feedback</Label>
           <HelpText>
             Markdown accepted (<code>[link text](url)</code>, <code>_italic_</code>,{' '}
-            <code>**bold**</code>, etc)
+            <code>**bold**</code>, etc). Your anonymous feedback will be posted publicly{' '}
+            <Link href={DISCUSSIONS_URL} target="_blank">
+              on GitHub
+            </Link>
+            .
           </HelpText>
           <Textarea
             id="feedback-comment"

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@storybook/theming';
+import { css, styled } from '@storybook/theming';
 import { Button, Link, OutlineCTA, styles } from '@storybook/design-system';
 
 const { code, color, spacing, typography } = styles;
@@ -109,6 +109,26 @@ const Textarea = styled.textarea`
   }
 `;
 
+const inaccessiblyVisuallyHidden = css`
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+`;
+
+const SpuriousLabel = styled.label`
+  ${inaccessiblyVisuallyHidden}
+`;
+
+const SpuriousTextarea = styled((props) => (
+  <Textarea {...props} aria-hidden="true" tabIndex={-1} />
+))`
+  ${inaccessiblyVisuallyHidden}
+`;
+
 export const Feedback = ({
   path,
   version,
@@ -121,10 +141,13 @@ export const Feedback = ({
 }: FeedbackProps) => {
   const [rating, setRating] = React.useState<'up' | 'down' | null>(forceRating);
   const [comment, setComment] = React.useState('');
+  const [spuriousComment, setSpuriousComment] = React.useState('');
   const [resultUrl, setResultUrl] = React.useState(forceResultUrl);
 
   const formRef = React.useRef<HTMLFormElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+
+  const commentFieldId = React.useMemo(() => Math.random().toString(36).substring(2, 15), []);
 
   const handleRatingClick = (whichRating) => () => {
     setRating(whichRating);
@@ -148,6 +171,7 @@ export const Feedback = ({
         codeLanguage,
         rating,
         comment,
+        spuriousComment,
       }),
     });
     if (response.ok) {
@@ -172,7 +196,7 @@ export const Feedback = ({
         </OutlineCTA>
       ) : (
         <>
-          <Label htmlFor="feedback-comment">Optional feedback</Label>
+          <Label htmlFor={commentFieldId}>Optional feedback</Label>
           <HelpText>
             Markdown accepted (<code>[link text](url)</code>, <code>_italic_</code>,{' '}
             <code>**bold**</code>, etc). Your anonymous feedback will be posted publicly{' '}
@@ -182,11 +206,18 @@ export const Feedback = ({
             .
           </HelpText>
           <Textarea
-            id="feedback-comment"
-            value={comment}
+            id={commentFieldId}
             ref={textareaRef}
+            value={comment}
             onChange={(event) => setComment(event.target.value)}
             placeholder={`What ${rating === 'up' ? 'was' : 'wasn’t'} helpful?`}
+          />
+          <SpuriousLabel htmlFor="comment" />
+          <SpuriousTextarea
+            id="comment"
+            value={spuriousComment}
+            onChange={(event) => setSpuriousComment(event.target.value)}
+            placeholder="Your comment"
           />
           <Button appearance="secondary" size="small">
             Submit feedback

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+import { styled } from '@storybook/theming';
+import { Button, Link, WithTooltip as DSWithToolip, styles } from '@storybook/design-system';
+
+const { code, color, spacing, typography } = styles;
+
+const DOCS_FEEDBACK_URL = '/.netlify/functions/docs-feedback';
+
+interface FeedbackProps {
+  path: string;
+  version: string;
+  framework: string;
+  codeLanguage: string;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.padding.small}px;
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+
+  > :first-child button {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  > :last-child button {
+    margin-left: -1px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+`;
+
+// TODO: Double focus outline
+const WithTooltip = (props) => <DSWithToolip trigger="click" tagName="span" {...props} />;
+
+const RatingButton = ({ selected, ...props }) => (
+  <Button appearance={selected ? 'secondaryOutline' : 'outline'} size="small" {...props} />
+);
+
+const Prompt = styled.p`
+  color: ${color.dark};
+  font-weight: ${typography.weight.bold};
+  font-size: ${typography.size.s2}px;
+  margin: 0;
+`;
+
+const StyledCommentForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${spacing.padding.small}px;
+  padding: ${spacing.padding.small}px ${spacing.padding.medium}px;
+  min-width: 420px;
+  max-width: 100vw;
+  font-size: ${typography.size.s2}px;
+`;
+
+const Label = styled.label`
+  font-size: ${typography.size.s2}px;
+  font-weight: ${typography.weight.bold};
+`;
+
+const HelpText = styled.p`
+  font-size: ${typography.size.s1}px;
+  margin: 0;
+
+  code {
+    ${code.small}
+    font-size: inherit;
+  }
+`;
+
+// Styles match SB DS Input
+const Textarea = styled.textarea`
+  appearance: none;
+  border: none;
+  background: ${color.lightest};
+  color: ${color.darkest};
+  font-size: ${typography.size.s2}px;
+  line-height: 20px;
+  padding: 10px 15px;
+  box-shadow: ${color.border} 0 0 0 1px inset;
+
+  width: 100%;
+  min-height: 150px;
+
+  &:focus {
+    box-shadow: ${color.secondary} 0 0 0 1px inset;
+  }
+
+  &::placeholder {
+    color: ${color.mediumdark};
+  }
+`;
+
+const CommentForm = ({ closeTooltip, ...props }) => {
+  const formRef = React.useRef<HTMLFormElement>(null);
+
+  React.useEffect(() => {
+    function handleKeydown(event) {
+      if (event.key === 'Escape') {
+        closeTooltip();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeydown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeydown);
+    };
+  });
+
+  return <StyledCommentForm ref={formRef} {...props} />;
+};
+
+export const Feedback = ({
+  path,
+  version,
+  framework,
+  codeLanguage,
+  // @ts-expect-error - For Storybook only
+  forceRating = null,
+  // @ts-expect-error - For Storybook only
+  forceResultUrl = '',
+}: FeedbackProps) => {
+  const [rating, setRating] = React.useState<'up' | 'down' | null>(forceRating);
+  const [comment, setComment] = React.useState('');
+  const [isDone, setIsDone] = React.useState(Boolean(forceResultUrl));
+  const [resultUrl, setResultUrl] = React.useState(forceResultUrl);
+
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    function handleClickOutside(event) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+        setRating(null);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  });
+
+  const handleClick = (whichRating) => () => {
+    setRating(whichRating);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const response = await fetch(DOCS_FEEDBACK_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        path,
+        version,
+        framework,
+        codeLanguage,
+        rating,
+        comment,
+      }),
+    });
+    if (response.ok) {
+      setIsDone(true);
+      setRating(null);
+      setComment('');
+      const { url } = await response.json();
+      setResultUrl(url);
+    }
+  };
+
+  const tooltip = ({ onHide: closeTooltip }) => (
+    <CommentForm
+      onSubmit={handleSubmit}
+      closeTooltip={() => {
+        closeTooltip();
+        setRating(null);
+      }}
+    >
+      {isDone ? (
+        <>
+          <Prompt>Thanks for your feedback!</Prompt>
+          {resultUrl && (
+            <p>
+              <Link href={resultUrl} target="_blank">
+                View your comment on GitHub
+              </Link>
+            </p>
+          )}
+        </>
+      ) : (
+        <>
+          <Label htmlFor="feedback-comment">Optional feedback</Label>
+          <HelpText>
+            Markdown accepted (<code>[link text](url)</code>, <code>_italic_</code>,{' '}
+            <code>**bold**</code>, etc)
+          </HelpText>
+          <Textarea
+            id="feedback-comment"
+            value={comment}
+            autoFocus
+            onChange={(event) => setComment(event.target.value)}
+            placeholder={`What ${rating === 'up' ? 'was' : 'wasn’t'} helpful?`}
+          />
+          <Button appearance="secondary" size="small">
+            Submit feedback
+          </Button>
+        </>
+      )}
+    </CommentForm>
+  );
+
+  return (
+    <Wrapper ref={wrapperRef}>
+      <ButtonGroup>
+        <WithTooltip startOpen={forceRating || forceResultUrl} tooltip={tooltip}>
+          <RatingButton selected={rating === 'up'} onClick={handleClick('up')}>
+            👍
+          </RatingButton>
+        </WithTooltip>
+        <WithTooltip startOpen={forceRating || forceResultUrl} tooltip={tooltip}>
+          <RatingButton selected={rating === 'down'} onClick={handleClick('down')}>
+            👎
+          </RatingButton>
+        </WithTooltip>
+      </ButtonGroup>
+      <Prompt>Was this page helpful?</Prompt>
+    </Wrapper>
+  );
+};

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -53,14 +53,10 @@ const Prompt = styled.p`
   margin: 0;
 `;
 
-const CommentForm = styled('form', {
+const Expandable = styled('div', {
   shouldForwardProp: (prop) => prop !== 'isExpanded',
 })<{ isExpanded?: boolean }>`
   flex: 1 0 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: ${spacing.padding.small}px;
   margin: ${spacing.padding.small}px 0 ${spacing.padding.large}px;
   padding: 0 1px;
   font-size: ${typography.size.s2}px;
@@ -68,6 +64,13 @@ const CommentForm = styled('form', {
   overflow: hidden;
   transition: height ${heightTransitionTime}ms ease-out;
   height: ${(props) => (props.isExpanded ? `${260 / 16}rem` : 0)};
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${spacing.padding.small}px;
 `;
 
 const Label = styled.label`
@@ -198,56 +201,59 @@ export const Feedback = ({
     setComment('');
   };
 
-  const form = (
-    <CommentForm ref={formRef} isExpanded={expanded} onSubmit={handleSubmit}>
-      {/* eslint-disable-next-line no-nested-ternary */}
-      {error ? (
-        <OutlineCTA badge={<Badge status="error">Error</Badge>} action={<></>}>
-          Something went wrong. Please try again.
-        </OutlineCTA>
-      ) : resultUrl ? (
-        <OutlineCTA
-          action={
-            <Link href={resultUrl} target="_blank" withArrow>
-              View your comment on GitHub
-            </Link>
-          }
-        >
-          Thanks for your feedback!
-        </OutlineCTA>
-      ) : (
-        <>
-          <Label htmlFor={commentFieldId}>Optional feedback</Label>
-          <HelpText>
-            Markdown accepted (<code>[link text](url)</code>, <code>_italic_</code>,{' '}
-            <code>**bold**</code>, etc). Your anonymous feedback will be posted publicly{' '}
-            <Link href={DISCUSSIONS_URL} target="_blank" tabIndex={!expanded ? -1 : undefined}>
-              on GitHub
-            </Link>
-            .
-          </HelpText>
-          <Textarea
-            id={commentFieldId}
-            ref={textareaRef}
-            value={comment}
-            onChange={(event) => setComment(event.target.value)}
-            placeholder={`What ${rating === 'up' ? 'was' : 'wasn’t'} helpful?`}
-            disabled={!expanded}
-          />
-          <SpuriousLabel htmlFor="comment" />
-          <SpuriousTextarea
-            id="comment"
-            value={spuriousComment}
-            onChange={(event) => setSpuriousComment(event.target.value)}
-            placeholder="Your comment"
-          />
-          <Button appearance="secondary" size="small" disabled={!expanded}>
-            Submit feedback
-          </Button>
-        </>
-      )}
-    </CommentForm>
+  let expandedContent = (
+    <Form ref={formRef} onSubmit={handleSubmit}>
+      <Label htmlFor={commentFieldId}>Optional feedback</Label>
+      <HelpText>
+        Markdown accepted (<code>[link text](url)</code>, <code>_italic_</code>,{' '}
+        <code>**bold**</code>, etc). Your anonymous feedback will be posted publicly{' '}
+        <Link href={DISCUSSIONS_URL} target="_blank" tabIndex={!expanded ? -1 : undefined}>
+          on GitHub
+        </Link>
+        .
+      </HelpText>
+      <Textarea
+        id={commentFieldId}
+        ref={textareaRef}
+        value={comment}
+        onChange={(event) => setComment(event.target.value)}
+        placeholder={`What ${rating === 'up' ? 'was' : 'wasn’t'} helpful?`}
+        disabled={!expanded}
+      />
+      <SpuriousLabel htmlFor="comment" />
+      <SpuriousTextarea
+        id="comment"
+        value={spuriousComment}
+        onChange={(event) => setSpuriousComment(event.target.value)}
+        placeholder="Your comment"
+      />
+      <Button appearance="secondary" size="small" disabled={!expanded}>
+        Submit feedback
+      </Button>
+    </Form>
   );
+
+  if (error) {
+    expandedContent = (
+      <OutlineCTA badge={<Badge status="error">Error</Badge>} action={<></>}>
+        Something went wrong. Please try again.
+      </OutlineCTA>
+    );
+  }
+
+  if (resultUrl) {
+    expandedContent = (
+      <OutlineCTA
+        action={
+          <Link href={resultUrl} target="_blank" withArrow>
+            View your comment on GitHub
+          </Link>
+        }
+      >
+        Thanks for your feedback!
+      </OutlineCTA>
+    );
+  }
 
   return (
     <Wrapper>
@@ -268,7 +274,7 @@ export const Feedback = ({
         </RatingButton>
       </ButtonGroup>
       <Prompt>Was this page helpful?</Prompt>
-      {form}
+      <Expandable isExpanded={expanded}>{expandedContent}</Expandable>
     </Wrapper>
   );
 };

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -147,6 +147,8 @@ export const Feedback = ({
   const [error, setError] = React.useState(forceError);
   const [resultUrl, setResultUrl] = React.useState(forceResultUrl);
 
+  const expanded = rating || resultUrl || error;
+
   const formRef = React.useRef<HTMLFormElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
 
@@ -155,9 +157,9 @@ export const Feedback = ({
   const handleRatingClick = (whichRating) => () => {
     setError('');
     setRating(whichRating);
-    textareaRef.current?.focus();
     setTimeout(() => {
       formRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      textareaRef.current?.focus();
     }, heightTransitionTime);
   };
 
@@ -202,7 +204,7 @@ export const Feedback = ({
   };
 
   const form = (
-    <CommentForm ref={formRef} isExpanded={error || resultUrl || rating} onSubmit={handleSubmit}>
+    <CommentForm ref={formRef} isExpanded={expanded} onSubmit={handleSubmit}>
       {/* eslint-disable-next-line no-nested-ternary */}
       {error ? (
         <OutlineCTA badge={<Badge status="error">Error</Badge>} action={<></>}>
@@ -224,7 +226,7 @@ export const Feedback = ({
           <HelpText>
             Markdown accepted (<code>[link text](url)</code>, <code>_italic_</code>,{' '}
             <code>**bold**</code>, etc). Your anonymous feedback will be posted publicly{' '}
-            <Link href={DISCUSSIONS_URL} target="_blank">
+            <Link href={DISCUSSIONS_URL} target="_blank" tabIndex={!expanded ? -1 : undefined}>
               on GitHub
             </Link>
             .
@@ -235,6 +237,7 @@ export const Feedback = ({
             value={comment}
             onChange={(event) => setComment(event.target.value)}
             placeholder={`What ${rating === 'up' ? 'was' : 'wasn’t'} helpful?`}
+            disabled={!expanded}
           />
           <SpuriousLabel htmlFor="comment" />
           <SpuriousTextarea
@@ -243,7 +246,7 @@ export const Feedback = ({
             onChange={(event) => setSpuriousComment(event.target.value)}
             placeholder="Your comment"
           />
-          <Button appearance="secondary" size="small">
+          <Button appearance="secondary" size="small" disabled={!expanded}>
             Submit feedback
           </Button>
         </>

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -167,10 +167,6 @@ export const Feedback = ({
     event.preventDefault();
 
     try {
-      const ipDataResponse = await fetch('https://www.cloudflare.com/cdn-cgi/trace');
-      const ipData = await ipDataResponse.text();
-      const ip = ipData.match(/ip=((?:\d+\.){3}\d+)/)?.[1];
-
       const response = await fetch(DOCS_FEEDBACK_URL, {
         method: 'POST',
         headers: {
@@ -184,7 +180,6 @@ export const Feedback = ({
           rating,
           comment,
           spuriousComment,
-          ip,
         }),
       });
       if (response.ok) {

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -63,7 +63,7 @@ const Expandable = styled('div', {
 
   overflow: hidden;
   transition: height ${heightTransitionTime}ms ease-out;
-  height: ${(props) => (props.isExpanded ? `${260 / 16}rem` : 0)};
+  height: ${(props) => (props.isExpanded ? `${290 / 16}rem` : 0)};
 `;
 
 const Form = styled.form`

--- a/src/functions/docs-feedback.js
+++ b/src/functions/docs-feedback.js
@@ -290,12 +290,24 @@ async function createDiscussion({ received, path, rating, comment, title }) {
   return url;
 }
 
+const requestsCache = {};
+
 exports.handler = async (event) => {
+  const now = Date.now();
   try {
     const { body } = event;
     const received = JSON.parse(body);
     console.info('Received:', JSON.stringify(received, null, 2));
-    const { rating, comment, spuriousComment } = received;
+    const { rating, comment, spuriousComment, ip } = received;
+
+    if (requestsCache[ip] && now - requestsCache[ip] < 1000) {
+      console.info(`Too many requests from ${ip}, ignoring`);
+      return {
+        statusCode: 200,
+        body: JSON.stringify({}),
+      };
+    }
+    requestsCache[ip] = now;
 
     if (spuriousComment) {
       console.info('Spurious comment, ignoring');

--- a/src/functions/docs-feedback.js
+++ b/src/functions/docs-feedback.js
@@ -1,0 +1,302 @@
+/* eslint-disable no-console, import/no-extraneous-dependencies */
+import dedent from 'dedent';
+import fetch from 'node-fetch';
+
+const pat = process.env.GITHUB_STORYBOOK_BOT_PAT;
+
+if (!pat) {
+  throw new Error('GITHUB_STORYBOOK_BOT_PAT not found in environment');
+}
+
+const repositoryOwner = 'storybookjs';
+const repositoryName = 'storybook';
+const repositoryId = 'MDEwOlJlcG9zaXRvcnk1NDE3MzU5Mw==';
+// Corresponds to "Documentation feedback" category
+const categoryId = 'DIC_kwDOAzqfmc4CWGpo';
+
+function createTitle(path) {
+  return `Feedback for ${path} docs page`;
+}
+
+function createRating(upOrDown, value) {
+  return `<!--start-${upOrDown}-->${value}<!--end-${upOrDown}-->`;
+}
+
+const ratingSymbols = {
+  up: '👍',
+  down: '👎',
+};
+
+function createBody({ isFirst, path, version, framework, codeLanguage, rating, comment }) {
+  const link = `**[${path}](https://storybook.js.org${path})**`;
+
+  // prettier-ignore
+  const meta = [
+    `| ${ratingSymbols[rating]} | v${version} | ${framework} | ${codeLanguage} |`,
+    '| - | - | - | - |',
+  ].join('\r\n');
+
+  let cumulativeRating;
+  if (isFirst) {
+    cumulativeRating = [
+      `| ${ratingSymbols['up']} | ${ratingSymbols['down']} |`,
+      '| :-: | :-: |',
+      // prettier-ignore
+      `| ${createRating('up', rating === 'up' ? 1 : 0)} | ${createRating('down', rating === 'down' ? 1 : 0)} |`,
+    ].join('\r\n');
+  }
+
+  return [link, meta, comment, cumulativeRating].filter((block) => Boolean(block)).join('\r\n\r\n');
+}
+
+function updateRating(body, rating) {
+  const regex = new RegExp(createRating(rating, '(\\d+)'));
+  const currentRating = body.match(regex)[1];
+  return body.replace(regex, createRating(rating, parseInt(currentRating, 10) + 1));
+}
+
+export async function queryGitHub(query, { variables = {} } = {}) {
+  let response;
+  try {
+    response = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(pat && {
+          Authorization: `bearer ${pat}`,
+          'User-Agent': 'storybook-bot',
+        }),
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (response) {
+      const { data, errors } = await response.json();
+      if (!errors || errors.length === 0) {
+        return data;
+      }
+      throw new Error(errors.map((error) => error.message).join('\n'));
+    }
+    throw new Error('No response');
+  } catch (error) {
+    throw new Error(
+      [
+        'Failed to fetch GitHub query',
+        `Response: ${JSON.stringify(response, null, 2)}`,
+        `Error: ${JSON.stringify(error, null, 2)}`,
+        `Query: {${query}`,
+        `variables: ${JSON.stringify(variables, null, 2)}`,
+      ].join('\n')
+    );
+  }
+}
+
+async function getDiscussion(title) {
+  console.info('Fetching discussions...');
+  let discussions = [];
+  let after;
+  do {
+    const {
+      repository: {
+        discussions: {
+          nodes: newDiscussions,
+          pageInfo: { hasNextPage, endCursor },
+        },
+      },
+      // eslint-disable-next-line no-await-in-loop
+    } = await queryGitHub(
+      dedent(`
+      query GetDiscussions($owner: String!, $name: String!, $after: String, $categoryId: ID!) {
+        repository(owner: $owner, name: $name) {
+          discussions(first: 100, after: $after, categoryId: $categoryId) {
+            nodes {
+              title
+              id
+              number
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    `),
+      {
+        variables: {
+          owner: repositoryOwner,
+          name: repositoryName,
+          after,
+          categoryId,
+        },
+      }
+    );
+
+    discussions = discussions.concat(newDiscussions);
+
+    after = hasNextPage ? endCursor : undefined;
+  } while (after);
+  console.info('... done!');
+
+  return discussions.find((discussion) => discussion.title === title);
+}
+
+async function updateDiscussion({ number, id, rating }) {
+  const {
+    repository: {
+      discussion: { body: currentBody },
+    },
+  } = await queryGitHub(
+    dedent(`
+      query GetDiscussion($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          discussion(number: $number) {
+            body
+          }
+        }
+      }
+    `),
+    {
+      variables: {
+        owner: repositoryOwner,
+        name: repositoryName,
+        number,
+      },
+    }
+  );
+
+  console.info('Updating discussion with new rating...');
+  const {
+    updateDiscussion: {
+      discussion: { body: updatedBody },
+    },
+  } = await queryGitHub(
+    dedent(`
+      mutation UpdateDiscussion($discussionId: ID!, $body: String!) { 
+        updateDiscussion(input: {
+          discussionId: $discussionId,
+          body: $body,
+        }) {
+          discussion {
+            body
+          }
+        }
+      }
+    `),
+    {
+      variables: {
+        discussionId: id,
+        body: updateRating(currentBody, rating),
+      },
+    }
+  );
+  console.info('... done!', 'Updated body:\n', updatedBody);
+}
+
+async function addDiscussionComment({ id, received, rating, comment }) {
+  console.info('Adding comment to discussion...');
+  const {
+    addDiscussionComment: {
+      comment: { body: addedComment, url },
+    },
+  } = await queryGitHub(
+    dedent(`
+      mutation AddDiscussionComment($discussionId: ID!, $body: String!) {
+        addDiscussionComment(input: {
+          discussionId: $discussionId,
+          body: $body,
+        }) {
+          comment {
+            body
+            url
+          }
+        }
+      }
+    `),
+    {
+      variables: {
+        discussionId: id,
+        body: createBody({ ...received, rating, comment }),
+      },
+    }
+  );
+  console.info('... done!, Added comment:', '\n', url, '\n', addedComment);
+  return url;
+}
+
+async function createDiscussion({ received, path, rating, comment, title }) {
+  console.info(`Creating new discussion for ${path}...`);
+  const {
+    createDiscussion: {
+      discussion: { title: addedTitle, body: addedBody, url },
+    },
+  } = await queryGitHub(
+    dedent(`
+      mutation CreateDiscussion($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) { 
+        createDiscussion(input: {
+          repositoryId: $repositoryId,
+          categoryId: $categoryId,
+          title: $title,
+          body: $body
+        }) {
+          discussion {
+            title
+            body
+            url
+          }
+        }
+      }
+    `),
+    {
+      variables: {
+        repositoryId,
+        categoryId,
+        title,
+        body: createBody({ isFirst: true, ...received, rating, comment }),
+      },
+    }
+  );
+  console.info('... done!, Added discussion:', '\n', url, '\n', addedTitle, '\n', addedBody);
+
+  return url;
+}
+
+exports.handler = async (event) => {
+  try {
+    const { body } = event;
+    const received = JSON.parse(body);
+    console.info('Received:', JSON.stringify(received, null, 2));
+    const { rating, comment } = received;
+
+    // TODO: This could contain a version?
+    const path = `/${received.path.split('/').slice(-2).join('/')}`;
+
+    const title = createTitle(path);
+
+    let url;
+
+    const currentDiscussion = await getDiscussion(title);
+
+    if (currentDiscussion) {
+      console.info(`Found discussion for ${path}`);
+      await updateDiscussion({ ...currentDiscussion, rating });
+
+      if (comment) {
+        url = await addDiscussionComment({ ...currentDiscussion, received, rating, comment });
+      }
+    } else {
+      url = await createDiscussion({ received, path, rating, comment, title });
+    }
+    // TODO: Return the new discussion/comment URL
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ url }),
+    };
+  } catch (error) {
+    console.info(error.toString());
+    return {
+      statusCode: 500,
+      body: error.toString(),
+    };
+  }
+};

--- a/src/functions/docs-feedback.js
+++ b/src/functions/docs-feedback.js
@@ -295,7 +295,15 @@ exports.handler = async (event) => {
     const { body } = event;
     const received = JSON.parse(body);
     console.info('Received:', JSON.stringify(received, null, 2));
-    const { rating, comment } = received;
+    const { rating, comment, spuriousComment } = received;
+
+    if (spuriousComment) {
+      console.info('Spurious comment, ignoring');
+      return {
+        statusCode: 200,
+        body: JSON.stringify({}),
+      };
+    }
 
     // TODO: This could contain a version?
     const path = `/${received.path.split('/').slice(-2).join('/')}`;

--- a/src/functions/docs-feedback.js
+++ b/src/functions/docs-feedback.js
@@ -295,19 +295,21 @@ const requestsCache = {};
 exports.handler = async (event) => {
   const now = Date.now();
   try {
-    const { body } = event;
-    const received = JSON.parse(body);
-    console.info('Received:', JSON.stringify(received, null, 2));
-    const { rating, comment, spuriousComment, ip } = received;
+    const { body, headers } = event;
 
+    const ip = headers['client-ip'];
     if (requestsCache[ip] && now - requestsCache[ip] < 1000) {
       console.info(`Too many requests from ${ip}, ignoring`);
       return {
-        statusCode: 200,
+        statusCode: 429,
         body: JSON.stringify({}),
       };
     }
     requestsCache[ip] = now;
+
+    const received = JSON.parse(body);
+    console.info('Received:', JSON.stringify(received, null, 2));
+    const { rating, comment, spuriousComment } = received;
 
     if (spuriousComment) {
       console.info('Spurious comment, ignoring');


### PR DESCRIPTION
Closes #537 

- Add Feedback component
- Add Feedback to DocsScreen
- Add docs-feedback cloud function
    - Creates/updates discussion on Storybook repo
    - Tracks cumulative rating
    - Re-opens closed discussions with new comments
- Attempt to reduce spam with honeypot and IP rate limiting

> ⚠️ Important note: Even though this is a preview, it is writing to the main Storybook monorepo. So please be careful what you say if you submit a comment and either delete your discussion when you're done or ping me to do it for you.

### Here's what it looks like in-page

![Screenshot of feedback widget on the page](https://user-images.githubusercontent.com/486540/235996458-1cd7bfb6-f20e-42d1-b378-30826eb10a07.png)

### And here's the resulting discussion

![Screenshot of discussion on Storybook's repo](https://user-images.githubusercontent.com/486540/236003413-8ff26523-ed97-4f63-a002-6894cb1a6524.png)
