### PR TITLE
Fix snippetType in tracking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run: yarn lint
+      - run: yarn test
 
       - run: GATSBY_CPU_COUNT=1 GATSBY_SKIP_ADDON_PAGES=true yarn build
       - run: yarn chromatic --exit-zero-on-changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run: yarn lint
-      - run: yarn test
 
       - run: GATSBY_CPU_COUNT=1 GATSBY_SKIP_ADDON_PAGES=true yarn build
+      - run: yarn test
       - run: yarn chromatic --exit-zero-on-changes
 
 workflows:

--- a/src/util/custom-events.test.ts
+++ b/src/util/custom-events.test.ts
@@ -1,0 +1,51 @@
+import { extractSnippetPath } from './custom-events';
+
+it('parses snippet type for install command', () => {
+  const npxResult = extractSnippetPath('common/init-command.npx.js.mdx');
+  expect(npxResult).toBe('init-command');
+
+  const pnpmResult = extractSnippetPath('common/init-command.pnpm.js.mdx');
+  expect(pnpmResult).toBe('init-command');
+});
+
+it('parses framework specific snippets [react]', () => {
+  const results = extractSnippetPath('react/button-story.js.mdx');
+  expect(results).toBe('button-story');
+});
+
+it('parses framework specific snippets [vue]', () => {
+  const results = extractSnippetPath('vue/button-story-with-addon-example.js.mdx');
+  expect(results).toBe('button-story-with-addon-example');
+});
+
+it('parses framework specific snippets [angular]', () => {
+  const results = extractSnippetPath('angular/button-story-with-addon-example.ts.mdx');
+  expect(results).toBe('button-story-with-addon-example');
+});
+
+it('parses framework specific snippets [web-components]', () => {
+  const results = extractSnippetPath('web-components/button-story-with-addon-example.js.mdx');
+  expect(results).toBe('button-story-with-addon-example');
+});
+
+it('parses framework specific snippets [ts-4.9]', () => {
+  const results = extractSnippetPath(
+    'common/button-story-baseline-with-satisfies-story-level.ts-4-9.mdx'
+  );
+  expect(results).toBe('button-story-baseline-with-satisfies-story-level');
+});
+
+it('parses common snippets', () => {
+  const results = extractSnippetPath('common/storybook-main-fallback-mdx.js.mdx');
+  expect(results).toBe('storybook-main-fallback-mdx');
+});
+
+it('parses snippet path with three levels', () => {
+  const results = extractSnippetPath('get-started/installation-problems/angular.mdx');
+  expect(results).toBe('installation-problems');
+});
+
+it('returns null for malformed snippet paths', () => {
+  const results = extractSnippetPath('malformed-snippet.mdx');
+  expect(results).toBeNull();
+});

--- a/src/util/custom-events.ts
+++ b/src/util/custom-events.ts
@@ -1,17 +1,5 @@
-/**
- * In: get-started/installation-command-section/angular.mdx
- * Out: installation-command-section
- *
- * In: common/init-command.npx.js.mdx
- * Out: init-command
- *
- * In: malformed-snippet.mdx
- * Out: null
- */
-const SNIPPET_TYPE_REGEX = /(?<=\/)[^/.]+/;
-
 export function logSnippetInteraction(framework, snippetPath) {
-  const snippetType = snippetPath.match(SNIPPET_TYPE_REGEX)?.[0];
+  const [, snippetType] = snippetPath.split('/');
 
   if (typeof window !== 'undefined' && (window as any).gtag && snippetType) {
     (window as any).gtag('event', 'click_snippet', { framework, snippet_type: snippetType });

--- a/src/util/custom-events.ts
+++ b/src/util/custom-events.ts
@@ -1,5 +1,25 @@
-export function logSnippetInteraction(framework, snippetPath) {
+export function extractSnippetPath(snippetPath: string) {
   const [, snippetType] = snippetPath.split('/');
+  if (!snippetType) {
+    return null;
+  }
+  const snippetTypeWithoutExtension = snippetType.replace(/\..+$/, '');
+
+  return snippetTypeWithoutExtension;
+}
+
+/**
+ * In: get-started/installation-command-section/angular.mdx
+ * Out: installation-command-section
+ *
+ * In: common/init-command.npx.js.mdx
+ * Out: init-command
+ *
+ * In: malformed-snippet.mdx
+ * Out: null
+ */
+export function logSnippetInteraction(framework, snippetPath) {
+  const snippetType = extractSnippetPath(snippetPath);
 
   if (typeof window !== 'undefined' && (window as any).gtag && snippetType) {
     (window as any).gtag('event', 'click_snippet', { framework, snippet_type: snippetType });


### PR DESCRIPTION
- Remove negative lookbehind regex pattern, which isn't supported in older Safari