### PR TITLE
Validate docs feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build-storybook.log
 # Pulled from monorepo
 src/content/docs
 src/generated/versions
+src/generated/docs-metadata.json
 
 # Env vars
 .env.production

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,7 @@ const buildPathWithFramework = require('./src/util/build-path-with-framework');
 const getReleaseBranchUrl = require('./src/util/get-release-branch-url');
 const { versionString, latestVersionString, isLatest } = require('./src/util/version-data');
 const sourceDXData = require('./src/util/source-dx-data');
-const { versions } = require('./src/util/versions');
+const { versions, versionsWithToc } = require('./src/util/versions');
 const createIntegrationsPages = require('./src/util/create-integrations-pages');
 const createHomePage = require('./src/util/create-home-page');
 const siteMetadata = require('./site-metadata');
@@ -20,6 +20,7 @@ const {
 } = siteMetadata;
 
 const docsTocWithPaths = addStateToToc(docsToc);
+const docsPagesSlugs = [];
 
 const nextVersionString = versions.preRelease[0]?.string;
 
@@ -155,7 +156,6 @@ exports.createPages = ({ actions, graphql }) => {
           });
 
           frameworks = [...coreFrameworks, ...communityFrameworks];
-          const docsPagesSlugs = [];
           const docsPagesEdgesBySlug = Object.fromEntries(
             docsPagesEdges.map((edge) => [edge.node.fields.slug, edge])
           );
@@ -246,6 +246,15 @@ function generateVersionsFile() {
   const next = getVersionData('next');
   const data = { ...latest, ...next };
   fs.writeFileSync('./public/versions-raw.json', JSON.stringify(data));
+}
+
+function generateDocsMetadataFile() {
+  const metadata = {
+    frameworks,
+    slugs: docsPagesSlugs,
+    versions: [latestVersionString, ...versionsWithToc.map(({ string }) => string)],
+  };
+  fs.writeFileSync('./src/generated/docs-metadata.json', JSON.stringify(metadata));
 }
 
 function updateRedirectsFile() {
@@ -356,6 +365,7 @@ exports.onPostBuild = async () => {
     await copyOtherSitemaps();
     await updateSitemapIndex();
     generateVersionsFile();
+    generateDocsMetadataFile();
     updateRedirectsFile();
   }
 };

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -273,7 +273,7 @@ function DocsScreen({ data, pageContext, location }) {
         {tocItem && (
           <Feedback
             key={fullPath}
-            path={fullPath}
+            slug={slug}
             version={versionString}
             framework={framework}
             codeLanguage={codeLanguage}

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -4,6 +4,8 @@ import { Badge, Button, Link, OutlineCTA, styles } from '@storybook/design-syste
 
 const { code, color, spacing, typography } = styles;
 
+const trickyHeader = process.env.GATSBY_DOCS_FEEDBACK_TRICKY_HEADER;
+
 const DOCS_FEEDBACK_URL = '/.netlify/functions/docs-feedback';
 const DISCUSSIONS_URL =
   'https://github.com/storybookjs/storybook/discussions/categories/documentation-feedback';
@@ -174,6 +176,7 @@ export const Feedback = ({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          [trickyHeader]: trickyHeader,
         },
         body: JSON.stringify({
           slug,

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -4,7 +4,12 @@ import { Badge, Button, Link, OutlineCTA, styles } from '@storybook/design-syste
 
 const { code, color, spacing, typography } = styles;
 
-const trickyHeader = process.env.GATSBY_DOCS_FEEDBACK_TRICKY_HEADER;
+const [, trickyHeaderKey, trickyHeaderValue] =
+  process.env.GATSBY_DOCS_FEEDBACK_TRICKY_HEADER?.match(/^key-(.+)-value-(.+)$/) || [
+    null,
+    'dev',
+    'value-for-local-dev',
+  ];
 
 const DOCS_FEEDBACK_URL = '/.netlify/functions/docs-feedback';
 const DISCUSSIONS_URL =
@@ -176,7 +181,7 @@ export const Feedback = ({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          [trickyHeader]: trickyHeader,
+          [trickyHeaderKey]: trickyHeaderValue,
         },
         body: JSON.stringify({
           slug,

--- a/src/components/screens/DocsScreen/Feedback.tsx
+++ b/src/components/screens/DocsScreen/Feedback.tsx
@@ -11,7 +11,7 @@ const DISCUSSIONS_URL =
 const heightTransitionTime = 100; // ms
 
 interface FeedbackProps {
-  path: string;
+  slug: string;
   version: string;
   framework: string;
   codeLanguage: string;
@@ -133,7 +133,7 @@ const SpuriousTextarea = styled((props) => (
 `;
 
 export const Feedback = ({
-  path,
+  slug,
   version,
   framework,
   codeLanguage,
@@ -176,7 +176,7 @@ export const Feedback = ({
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          path,
+          slug,
           version,
           framework,
           codeLanguage,

--- a/src/functions/docs-feedback.js
+++ b/src/functions/docs-feedback.js
@@ -8,11 +8,17 @@ import siteMetadata from '../../site-metadata';
 import docsMetadata from '../generated/docs-metadata.json';
 import buildPathWithFramework from '../util/build-path-with-framework';
 
-const { siteUrl } = siteMetadata;
 const { frameworks, slugs, versions } = docsMetadata;
 
+const siteUrl = process.env.URL;
 const pat = process.env.GITHUB_STORYBOOK_BOT_PAT;
 const trickyHeader = process.env.GATSBY_DOCS_FEEDBACK_TRICKY_HEADER;
+/**
+ * Netlify doesn't provide a way to determine the deploy context, but we can
+ * adjust the value of a custom env var per-context, so we infer the context
+ * from that.
+ */
+const isProduction = trickyHeader.endsWith('-prod');
 
 if (!pat) {
   throw new Error('GITHUB_STORYBOOK_BOT_PAT not found in environment');
@@ -340,7 +346,7 @@ exports.handler = async (event) => {
     const path = slug.replace('/docs', '');
 
     const hasValidTrickyHeader = headers[trickyHeader] === trickyHeader;
-    const hasValidOrigin = headers['origin'] === siteUrl;
+    const hasValidOrigin = isProduction ? headers['origin'] === siteUrl : true;
     const hasValidReferer = headers['referer'].endsWith(path);
 
     if (!hasValidTrickyHeader || !hasValidOrigin || !hasValidReferer) {

--- a/src/functions/docs-feedback.js
+++ b/src/functions/docs-feedback.js
@@ -2,6 +2,8 @@
 import dedent from 'dedent';
 import fetch from 'node-fetch';
 
+import buildPathWithFramework from '../util/build-path-with-framework';
+
 const pat = process.env.GITHUB_STORYBOOK_BOT_PAT;
 
 if (!pat) {
@@ -36,7 +38,8 @@ function createDiscussionBody(rating) {
   ].join('\r\n');
 }
 
-function createCommentBody({ path, version, framework, codeLanguage, rating, comment }) {
+function createCommentBody({ slug, version, framework, codeLanguage, rating, comment }) {
+  const path = buildPathWithFramework(slug, framework, version);
   const link = `**[${path}](https://storybook.js.org${path})**`;
 
   // prettier-ignore
@@ -326,8 +329,7 @@ exports.handler = async (event) => {
       };
     }
 
-    // TODO: This could contain a version?
-    const path = `/${received.path.split('/').slice(-2).join('/')}`;
+    const path = received.slug.replace('/docs', '');
 
     const title = createTitle(path);
 

--- a/src/functions/docs-feedback.js
+++ b/src/functions/docs-feedback.js
@@ -329,7 +329,7 @@ exports.handler = async (event) => {
       };
     }
 
-    const ip = headers['client-ip'];
+    const ip = headers['x-nf-client-connection-ip'];
     if (requestsCache[ip] && now - requestsCache[ip] < 1000) {
       console.info(`Too many requests from ${ip}, ignoring`);
       return {

--- a/src/functions/docs-feedback.js
+++ b/src/functions/docs-feedback.js
@@ -8,9 +8,7 @@ import siteMetadata from '../../site-metadata';
 import docsMetadata from '../generated/docs-metadata.json';
 import buildPathWithFramework from '../util/build-path-with-framework';
 
-const {
-  urls: { homepageUrl },
-} = siteMetadata;
+const { siteUrl } = siteMetadata;
 const { frameworks, slugs, versions } = docsMetadata;
 
 const pat = process.env.GITHUB_STORYBOOK_BOT_PAT;
@@ -341,12 +339,19 @@ exports.handler = async (event) => {
 
     const path = slug.replace('/docs', '');
 
-    if (
-      !headers[trickyHeader] ||
-      headers['origin'] !== homepageUrl ||
-      headers['referer'].endsWith(path)
-    ) {
-      console.info('Invalid header, ignoring');
+    const hasValidTrickyHeader = headers[trickyHeader] === trickyHeader;
+    const hasValidOrigin = headers['origin'] === siteUrl;
+    const hasValidReferer = headers['referer'].endsWith(path);
+
+    if (!hasValidTrickyHeader || !hasValidOrigin || !hasValidReferer) {
+      console.info('Invalid headers, ignoring');
+      console.info(
+        JSON.stringify(
+          { hasValidTrickyHeader, hasValidOrigin, siteUrl, hasValidReferer, path, headers },
+          null,
+          2
+        )
+      );
       return {
         statusCode: 401,
         body: JSON.stringify({}),
@@ -361,13 +366,29 @@ exports.handler = async (event) => {
       };
     }
 
-    if (
-      !frameworks.includes(framework) ||
-      !slugs.includes(slug) ||
-      !versions.includes(version) ||
-      !Object.keys(ratingSymbols).includes(rating)
-    ) {
+    const hasValidFramework = frameworks.includes(framework);
+    const hasValidSlug = slugs.includes(slug);
+    const hasValidVersion = versions.includes(version);
+    const hasValidRating = Object.keys(ratingSymbols).includes(rating);
+
+    if (!hasValidFramework || !hasValidVersion || !hasValidRating) {
       console.info('Invalid data, ignoring');
+      console.info(
+        JSON.stringify(
+          {
+            hasValidFramework,
+            framework,
+            hasValidSlug,
+            slug,
+            hasValidVersion,
+            version,
+            hasValidRating,
+            rating,
+          },
+          null,
+          2
+        )
+      );
       return {
         statusCode: 401,
         body: JSON.stringify({}),


### PR DESCRIPTION
> **Note**: I suggest reviewing [commit-by-commit](https://github.com/storybookjs/frontpage/pull/552/commits). The changes were carefully structured to aid review.

![](https://github.com/storybookjs/frontpage/assets/486540/27572e74-5936-4592-80b7-6e83f674ed57)

This is an effort to harden the docs feedback widget against scammers and other bad actors _without_ going all the way to requiring users to authenticate first.

- Generate docs-metadata file on build
- Update docs-feedback to use `slug` instead of `path`
    - Easier than removing the version (sometimes) and framework from the path
    - Allows for direct comparison with docs slugs
- Validate submitted data against allowed values
    - Check slug, version, framework, and rating
- Validate against a tricky header on the request
    - Based on [Netlify's guidance](https://answers.netlify.com/t/support-guide-how-to-apply-access-control-for-netlify-functions/46519)
    - It's named "tricky" instead of "secret" because the value isn't a critical secret
        - It's used on the frontend and passed in the clear in the request, so it cannot be truly secret
- Fix retrieval of client ip
- Validate against other available headers

### How to test

1. Open **this page** in the deploy preview: [/docs/react/contribute/new-snippets](https://deploy-preview-552--storybook-frontpage.netlify.app/docs/react/contribute/new-snippets)
    - It works for all pages, but this one is unlikely to receive legitimate feedback, and is thus good for QA efforts
2. Submit some feedback
3. Confirm it works
4. Delete your new discussion
5. Attempt to spoof a request (using Postman or something like it) while pretending you don't know about the checks in this PR
    - Reference the [source](https://github.com/storybookjs/frontpage/pull/552/files#diff-7f9c27a6ddd90c0c64c9b2658386476b351f96b411d6ccfe627d106c9a652aacR175-R190) for the URL and shape of the request body
6. Confirm you receive a 401 response code
7. You can check the [function logs](https://app.netlify.com/sites/storybook-frontpage/functions/docs-feedback?scope=deploypreview:552) for additional info