### PR TITLE
Handle versioned links in relative-to-root-links

### DIFF
--- a/src/util/relative-to-root-links.js
+++ b/src/util/relative-to-root-links.js
@@ -1,22 +1,33 @@
 const buildPathWithFramework = require('./build-path-with-framework');
 
 /**
- *
  * Convert relative links in docs to relative but from the /docs root
  *
  * ./docs-page with path docs/react/writing-docs/introduction becomes /docs/react/writing-docs/docs-page
  * ../addons/writing-addons becomes /docs/react/addons/writing-addons
- * ../../app/ember/README remain untouched (these are converted to github links elsewhere)
+ * ../../../release-6-5/docs/api/csf.md becomes /docs/6.5/react/api/csf.md
+ *
+ * ../../app/ember/README remains untouched (these are converted to github links elsewhere)
  * /addons remains untouched
  */
-function relativeToRootLinks(href, framework, path = '', overrideVersion) {
+function relativeToRootLinks(href, framework, path = '', overrideVersionIn) {
   const relativeUrlRegex = /^(?!\.\.\/\.\.\/)(\.\/)(.*)$/;
   const multiLevelRelativeUrlRegex = /^(?!\.\.\/\.\.\/)(\.\.\/)(.*)$/;
 
   let url = href;
 
-  if (relativeUrlRegex.test(href)) {
-    // rewrite ./some_path style urls to /docs/version?/framework/parent/some_path
+  let overrideVersion = overrideVersionIn;
+  const versionedUrl = url.match(/\/release-(\d+-\d+)\//);
+  if (versionedUrl) {
+    // rewrite ../../../release-#-#/docs/parent/some-path style urls to /docs/version/framework/parent/some-path
+    overrideVersion = versionedUrl[1].split('-').join('.');
+    url = buildPathWithFramework(
+      href.replace(/.*\/docs\/(.*)/, '/docs/$1'),
+      framework,
+      overrideVersion
+    );
+  } else if (relativeUrlRegex.test(href)) {
+    // rewrite ./some-path style urls to /docs/version?/framework/parent/some-path
     const slugParts = path.split('/').filter((p) => !!p);
     slugParts.splice(-1, 1, href.replace(relativeUrlRegex, '$2'));
     url = `/${slugParts.join('/')}`;
@@ -25,7 +36,7 @@ function relativeToRootLinks(href, framework, path = '', overrideVersion) {
       url = url.replace(/\/docs\/(?:\d\.\d\/)?/, `/docs/${overrideVersion}/`);
     }
   } else if (multiLevelRelativeUrlRegex.test(href)) {
-    // rewrite ../parent/some_path style urls to /docs/version?/framework/parent/some_path
+    // rewrite ../parent/some-path style urls to /docs/version?/framework/parent/some-path
     url = buildPathWithFramework(
       href.replace(multiLevelRelativeUrlRegex, '/docs/$2'),
       framework,

--- a/src/util/relative-to-root-links.test.ts
+++ b/src/util/relative-to-root-links.test.ts
@@ -1,0 +1,49 @@
+import relativeToRootLinks from './relative-to-root-links';
+
+it('transforms sibling-level links', () => {
+  const rootUrl = relativeToRootLinks(
+    './args.md',
+    'react',
+    '/docs/react/writing-stories/introduction'
+  );
+  expect(rootUrl).toEqual('/docs/react/writing-stories/args.md');
+});
+
+it('transforms parent-level links', () => {
+  const rootUrl = relativeToRootLinks(
+    '../writing-docs/introduction.md',
+    'react',
+    '/docs/react/writing-stories/introduction'
+  );
+  expect(rootUrl).toEqual('/docs/react/writing-docs/introduction.md');
+});
+
+it('transforms specific-version links', () => {
+  const rootUrl = relativeToRootLinks(
+    '../../../release-6-5/docs/api/csf.md',
+    'react',
+    '/docs/react/configure/babel'
+  );
+  expect(rootUrl).toEqual('/docs/6.5/react/api/csf.md');
+});
+
+it('does not transform non-versioned upper-level links', () => {
+  const rootUrl = relativeToRootLinks(
+    '../../foo/bar/README.md',
+    'react',
+    '/docs/react/writing-stories/introduction'
+  );
+  expect(rootUrl).toEqual('../../foo/bar/README.md');
+
+  const rootUrl2 = relativeToRootLinks(
+    '../../../foo/bar/README.md',
+    'react',
+    '/docs/react/writing-stories/introduction'
+  );
+  expect(rootUrl2).toEqual('../../../foo/bar/README.md');
+});
+
+it('does not transform non-relative links', () => {
+  const rootUrl = relativeToRootLinks('/foo', 'react', '/docs/react/writing-stories/introduction');
+  expect(rootUrl).toEqual('/foo');
+});


### PR DESCRIPTION
This approach will eventually[^1] replace `LinkWithVersion`. It allows for functional links when viewing on GitHub.

- `../../../release-6-5/docs/api/csf.md` → `/docs/6.5/react/api/csf.md`
- Add tests

[^1]: For now, `LinkWithVersion` remains available in MDX, so that I can update the actual docs content in the monorepo. After that, I'll remove that component, as it is no longer necessary.