### PR TITLE
Remove `.md` extension on docs links

### DIFF
--- a/src/util/relative-to-root-links.js
+++ b/src/util/relative-to-root-links.js
@@ -1,13 +1,17 @@
 const buildPathWithFramework = require('./build-path-with-framework');
 
+function removeMdExtension(path) {
+  return path.replace(/\.md$/, '');
+}
+
 /**
  * Convert relative links in docs to relative but from the /docs root
  *
  * ./docs-page with path docs/react/writing-docs/introduction becomes /docs/react/writing-docs/docs-page
  * ../addons/writing-addons becomes /docs/react/addons/writing-addons
- * ../../../release-6-5/docs/api/csf.md becomes /docs/6.5/react/api/csf.md
+ * ../../../release-6-5/docs/api/csf.md becomes /docs/6.5/react/api/csf
  *
- * ../../app/ember/README remains untouched (these are converted to github links elsewhere)
+ * ../../app/ember/README.md remains untouched (these are converted to github links elsewhere)
  * /addons remains untouched
  */
 function relativeToRootLinks(href, framework, path = '', overrideVersionIn) {
@@ -26,7 +30,10 @@ function relativeToRootLinks(href, framework, path = '', overrideVersionIn) {
       framework,
       overrideVersion
     );
-  } else if (relativeUrlRegex.test(href)) {
+    return removeMdExtension(url);
+  }
+
+  if (relativeUrlRegex.test(href)) {
     // rewrite ./some-path style urls to /docs/version?/framework/parent/some-path
     const slugParts = path.split('/').filter((p) => !!p);
     slugParts.splice(-1, 1, href.replace(relativeUrlRegex, '$2'));
@@ -35,13 +42,18 @@ function relativeToRootLinks(href, framework, path = '', overrideVersionIn) {
     if (overrideVersion) {
       url = url.replace(/\/docs\/(?:\d\.\d\/)?/, `/docs/${overrideVersion}/`);
     }
-  } else if (multiLevelRelativeUrlRegex.test(href)) {
+
+    return removeMdExtension(url);
+  }
+
+  if (multiLevelRelativeUrlRegex.test(href)) {
     // rewrite ../parent/some-path style urls to /docs/version?/framework/parent/some-path
     url = buildPathWithFramework(
       href.replace(multiLevelRelativeUrlRegex, '/docs/$2'),
       framework,
       overrideVersion
     );
+    return removeMdExtension(url);
   }
 
   return url;

--- a/src/util/relative-to-root-links.test.ts
+++ b/src/util/relative-to-root-links.test.ts
@@ -6,7 +6,7 @@ it('transforms sibling-level links', () => {
     'react',
     '/docs/react/writing-stories/introduction'
   );
-  expect(rootUrl).toEqual('/docs/react/writing-stories/args.md');
+  expect(rootUrl).toEqual('/docs/react/writing-stories/args');
 });
 
 it('transforms parent-level links', () => {
@@ -15,7 +15,7 @@ it('transforms parent-level links', () => {
     'react',
     '/docs/react/writing-stories/introduction'
   );
-  expect(rootUrl).toEqual('/docs/react/writing-docs/introduction.md');
+  expect(rootUrl).toEqual('/docs/react/writing-docs/introduction');
 });
 
 it('transforms specific-version links', () => {
@@ -24,7 +24,7 @@ it('transforms specific-version links', () => {
     'react',
     '/docs/react/configure/babel'
   );
-  expect(rootUrl).toEqual('/docs/6.5/react/api/csf.md');
+  expect(rootUrl).toEqual('/docs/6.5/react/api/csf');
 });
 
 it('does not transform non-versioned upper-level links', () => {


### PR DESCRIPTION
Re-doing the already-approved-and-merged https://github.com/storybookjs/frontpage/pull/558, due to a GitHub hiccup causing it to not actually be merged.