### PR TITLE
Remove LinkWithVersion

### DIFF
--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -156,17 +156,6 @@ function DocsScreen({ data, pageContext, location }) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [framework]);
-  const LinkWithVersion = useMemo(() => {
-    return ({ children, href, version, ...props }) => {
-      const url = relativeToRootLinks(href, framework, location.pathname, version);
-      return (
-        <a href={url} {...props}>
-          {children}
-        </a>
-      );
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [framework]);
 
   const features = featureGroups.flatMap((group) => group.features);
   const feature = features.find((fs) => `/docs${fs.path}/` === slug);
@@ -241,7 +230,6 @@ function DocsScreen({ data, pageContext, location }) {
             FrameworkSupportTable: FrameworkSupportTableWithFeaturesAndCurrentFramework,
             YouTubeCallout,
             a: LinksWithPrefix,
-            LinkWithVersion,
           }}
         >
           <StyledHighlight withHTMLChildren={false}>

--- a/src/util/relative-to-root-links.js
+++ b/src/util/relative-to-root-links.js
@@ -14,17 +14,16 @@ function removeMdExtension(path) {
  * ../../app/ember/README.md remains untouched (these are converted to github links elsewhere)
  * /addons remains untouched
  */
-function relativeToRootLinks(href, framework, path = '', overrideVersionIn) {
+function relativeToRootLinks(href, framework, path = '') {
   const relativeUrlRegex = /^(?!\.\.\/\.\.\/)(\.\/)(.*)$/;
   const multiLevelRelativeUrlRegex = /^(?!\.\.\/\.\.\/)(\.\.\/)(.*)$/;
 
   let url = href;
 
-  let overrideVersion = overrideVersionIn;
   const versionedUrl = url.match(/\/release-(\d+-\d+)\//);
   if (versionedUrl) {
     // rewrite ../../../release-#-#/docs/parent/some-path style urls to /docs/version/framework/parent/some-path
-    overrideVersion = versionedUrl[1].split('-').join('.');
+    const overrideVersion = versionedUrl[1].split('-').join('.');
     url = buildPathWithFramework(
       href.replace(/.*\/docs\/(.*)/, '/docs/$1'),
       framework,
@@ -38,21 +37,12 @@ function relativeToRootLinks(href, framework, path = '', overrideVersionIn) {
     const slugParts = path.split('/').filter((p) => !!p);
     slugParts.splice(-1, 1, href.replace(relativeUrlRegex, '$2'));
     url = `/${slugParts.join('/')}`;
-
-    if (overrideVersion) {
-      url = url.replace(/\/docs\/(?:\d\.\d\/)?/, `/docs/${overrideVersion}/`);
-    }
-
     return removeMdExtension(url);
   }
 
   if (multiLevelRelativeUrlRegex.test(href)) {
     // rewrite ../parent/some-path style urls to /docs/version?/framework/parent/some-path
-    url = buildPathWithFramework(
-      href.replace(multiLevelRelativeUrlRegex, '/docs/$2'),
-      framework,
-      overrideVersion
-    );
+    url = buildPathWithFramework(href.replace(multiLevelRelativeUrlRegex, '/docs/$2'), framework);
     return removeMdExtension(url);
   }
 


### PR DESCRIPTION
- No longer used, per https://github.com/storybookjs/frontpage/pull/555 & https://github.com/storybookjs/storybook/pull/22966
- Simplify `relativeToRootLinks`