### PR TITLE
Update recipes to include codemod instructions

### DIFF
--- a/src/content/recipes/@emotion/styled.md
+++ b/src/content/recipes/@emotion/styled.md
@@ -29,25 +29,7 @@ If you’d like to see the example code of this recipe, check out the [example r
 
 ![Completed Emotion example with theme switcher](https://user-images.githubusercontent.com/18172605/208312563-875ca3b0-e7bc-4401-a445-4553b48068ed.gif)
 
-## Auto-config
-
-As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Emotion.
-
-To try it out, run the following commands:
-
-```shell
-# Install the addon
-yarn add -D @storybook/addon-styling
-
-# Run the postinstall script from the root of your project
-node node_modules/@storybook/addon-styling/bin/postinstall.js
-```
-
-If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
-
-## Manual
-
-### Install `@storybook/addon-styling`
+## Install `@storybook/addon-styling`
 
 Add the `@storybook/addon-styling` package to your DevDependencies
 
@@ -63,6 +45,21 @@ module.exports = {
   addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
 };
 ```
+
+## Auto-config
+
+As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Emotion.
+
+To try it out, run the following script:
+
+```shell
+# Run the postinstall script from the root of your project
+node node_modules/@storybook/addon-styling/bin/postinstall.js
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
+
+## Manual
 
 ### How to setup `GlobalStyles`
 

--- a/src/content/recipes/@emotion/styled.md
+++ b/src/content/recipes/@emotion/styled.md
@@ -29,7 +29,25 @@ If you’d like to see the example code of this recipe, check out the [example r
 
 ![Completed Emotion example with theme switcher](https://user-images.githubusercontent.com/18172605/208312563-875ca3b0-e7bc-4401-a445-4553b48068ed.gif)
 
-## Install `@storybook/addon-styling`
+## Auto-config
+
+As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Emotion.
+
+To try it out, run the following commands:
+
+```shell
+# Install the addon
+yarn add -D @storybook/addon-styling
+
+# Run the postinstall script from the root of your project
+node node_modules/@storybook/addon-styling/bin/postinstall.js
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
+
+## Manual
+
+### Install `@storybook/addon-styling`
 
 Add the `@storybook/addon-styling` package to your DevDependencies
 
@@ -46,7 +64,7 @@ module.exports = {
 };
 ```
 
-## How to setup `GlobalStyles`
+### How to setup `GlobalStyles`
 
 UIs often have a set of global styles that are applied to every component like CSS resets, `font-size`, `font-family`, and colors.
 
@@ -82,7 +100,7 @@ If you already have `Global` in your app, you can import it into `.storybook/pre
 
 </div>
 
-## Using Emotion in components
+### Using Emotion in components
 
 Let’s update some of our example components to use Emotion instead. Open up the Button component in `./src/stories/button.js.` and replace it with the following code:
 
@@ -185,7 +203,7 @@ Button.defaultProps = {
 
 Now the `Button` component is made with Emotion. In Storybook, you won't notice a visual difference. But if you inspect the DOM, you'll see hashed CSS-in-JS classnames.
 
-## Provide a theme for Emotion in Storybook
+### Provide a theme for Emotion in Storybook
 
 ![Switching over to using a theme for emotion in storybook](https://user-images.githubusercontent.com/18172605/208312571-431a182d-fe2b-40e7-a21f-aaadf55c899e.gif)
 
@@ -286,7 +304,7 @@ Now, components made with Emotion will get the theme through the `theme` prop al
 
 <!-- prettier-ignore-end -->
 
-## Add a theme switcher tool using `@storybook/addon-styling`
+### Add a theme switcher tool using `@storybook/addon-styling`
 
 Dark mode has become an increasingly popular offering on the web. This can be achieved quickly using themes.
 

--- a/src/content/recipes/@mui/material.md
+++ b/src/content/recipes/@mui/material.md
@@ -18,16 +18,30 @@ Storybook is a frontend workbench for building UIs in isolation. By combining St
 - 🎨 Load your custom theme and add a theme switcher
 - ♻️ Reuse Material UI types to auto-generate story controls
 
+## Install `@storybook/addon-styling`
+
+Add the `@storybook/addon-styling` package to your DevDependencies
+
+```shell
+yarn add -D @storybook/addon-styling
+```
+
+Then register with Storybook in `.storybook/main.js`.
+
+```js
+module.exports = {
+  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
+};
+```
+
 ## Auto-config
 
 As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Material UI.
 
-To try it out, run the following commands:
+To try it out, run the following script:
 
 ```shell
-# Install the addon
-yarn add -D @storybook/addon-styling
-
 # Run the postinstall script from the root of your project
 node node_modules/@storybook/addon-styling/bin/postinstall.js
 ```
@@ -105,22 +119,7 @@ export const darkTheme = createTheme({
 });
 ```
 
-First of all, install our [`@storybook/addon-styling`](https://github.com/storybookjs/addon-styling) addon.
-
-```shell
-yarn add -D @storybook/addon-styling
-```
-
-Then register it with Storybook in `.storybook/main.js`
-
-```js
-module.exports = {
-  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
-};
-```
-
-And finally apply the custom themes to our stories. We’ll need to wrap them in Material UI’s `ThemeProvider` using the `withThemeFromJSXProvider` decorator.
+Then apply the custom themes to our stories. We’ll need to wrap them in Material UI’s `ThemeProvider` using the `withThemeFromJSXProvider` decorator.
 
 ```js
 // .storybook/preview.js

--- a/src/content/recipes/@mui/material.md
+++ b/src/content/recipes/@mui/material.md
@@ -18,7 +18,25 @@ Storybook is a frontend workbench for building UIs in isolation. By combining St
 - 🎨 Load your custom theme and add a theme switcher
 - ♻️ Reuse Material UI types to auto-generate story controls
 
-## Bundle fonts and icons for better perf
+## Auto-config
+
+As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Material UI.
+
+To try it out, run the following commands:
+
+```shell
+# Install the addon
+yarn add -D @storybook/addon-styling
+
+# Run the postinstall script from the root of your project
+node node_modules/@storybook/addon-styling/bin/postinstall.js
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
+
+## Manual
+
+### Bundle fonts and icons for better perf
 
 Material UI depends on two fonts to render as intended, Google’s [`Roboto`](https://fonts.google.com/specimen/Roboto) and [`Material Icons`](https://fonts.google.com/icons?query=Christian+Robertson&icon.style=Outlined&icon.set=Material+Icons). While you can load these fonts directly from the Google Fonts CDN, bundling fonts with Storybook is better for performance.
 
@@ -44,7 +62,7 @@ import '@fontsource/roboto/700.css';
 import '@fontsource/material-icons';
 ```
 
-## Load custom themes and add a theme switcher
+### Load custom themes and add a theme switcher
 
 Material UI comes with a default theme out of the box, but you can also create and provide your own themes. Given the popularity of dark mode, you'll likely end with more than one custom theme. Let's look at how you can load custom themes and switch between them with just a click.
 

--- a/src/content/recipes/styled-components.md
+++ b/src/content/recipes/styled-components.md
@@ -28,7 +28,25 @@ If you’d like to see the example code of this recipe, check out the [example r
 
 ![Completed styled-components example with theme switcher](https://user-images.githubusercontent.com/18172605/208312563-875ca3b0-e7bc-4401-a445-4553b48068ed.gif)
 
-## Install `@storybook/addon-styling`
+## Auto-config
+
+As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with styled-components.
+
+To try it out, run the following commands:
+
+```shell
+# Install the addon
+yarn add -D @storybook/addon-styling
+
+# Run the postinstall script from the root of your project
+node node_modules/@storybook/addon-styling/bin/postinstall.js
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
+
+## Manual
+
+### Install `@storybook/addon-styling`
 
 Add the `@storybook/addon-styling` package to your DevDependencies
 
@@ -45,7 +63,7 @@ module.exports = {
 };
 ```
 
-## How to setup `GlobalStyles`
+### How to setup `GlobalStyles`
 
 UIs often have a set of global styles that are applied to every component like CSS resets, `font-size`, `font-family`, and colors.
 
@@ -77,7 +95,7 @@ If you already have `GlobalStyles` in your app, you can import it into `.storybo
 
 </div>
 
-## Use styled-components in components
+### Use styled-components in components
 
 Let’s update some of our example components to use styled-components instead. Open up the Button component in `./src/stories/button.js.` and replace it with the following code:
 
@@ -179,7 +197,7 @@ Button.defaultProps = {
 
 Now the `Button` component is made with styled-components. In Storybook, you won't notice a visual difference. But if you inspect the DOM, you'll see hashed CSS-in-JS classnames.
 
-## Provide a theme for styled-components in Storybook
+### Provide a theme for styled-components in Storybook
 
 ![Switching over to using a theme for styled-components in storybook](https://user-images.githubusercontent.com/18172605/208312571-431a182d-fe2b-40e7-a21f-aaadf55c899e.gif)
 
@@ -276,7 +294,7 @@ Now, components made with styled-components will get the theme through the `them
 
 <!-- prettier-ignore-end -->
 
-## Add a theme switcher tool using `@storybook/addon-styling`
+### Add a theme switcher tool using `@storybook/addon-styling`
 
 Dark mode has become an increasingly popular offering on the web. This can be achieved quickly using themes.
 

--- a/src/content/recipes/styled-components.md
+++ b/src/content/recipes/styled-components.md
@@ -28,25 +28,7 @@ If you’d like to see the example code of this recipe, check out the [example r
 
 ![Completed styled-components example with theme switcher](https://user-images.githubusercontent.com/18172605/208312563-875ca3b0-e7bc-4401-a445-4553b48068ed.gif)
 
-## Auto-config
-
-As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with styled-components.
-
-To try it out, run the following commands:
-
-```shell
-# Install the addon
-yarn add -D @storybook/addon-styling
-
-# Run the postinstall script from the root of your project
-node node_modules/@storybook/addon-styling/bin/postinstall.js
-```
-
-If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
-
-## Manual
-
-### Install `@storybook/addon-styling`
+## Install `@storybook/addon-styling`
 
 Add the `@storybook/addon-styling` package to your DevDependencies
 
@@ -62,6 +44,21 @@ module.exports = {
   addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
 };
 ```
+
+## Auto-config
+
+As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with styled-components.
+
+To try it out, run the following script:
+
+```shell
+# Run the postinstall script from the root of your project
+node node_modules/@storybook/addon-styling/bin/postinstall.js
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
+
+## Manual
 
 ### How to setup `GlobalStyles`
 

--- a/src/content/recipes/tailwindcss.md
+++ b/src/content/recipes/tailwindcss.md
@@ -26,16 +26,30 @@ In this post, we will:
 
 ![Finished example of Tailwind CSS in Storybook with a theme switcher](https://user-images.githubusercontent.com/18172605/208201389-1f448dbb-978c-442e-9d6b-7bf3fea63e64.gif)
 
+## Install `@storybook/addon-styling`
+
+Add the `@storybook/addon-styling` package to your DevDependencies
+
+```shell
+yarn add -D @storybook/addon-styling
+```
+
+Then register with Storybook in `.storybook/main.js`.
+
+```js
+module.exports = {
+  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
+};
+```
+
 ## Auto-config
 
 As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Tailwind.
 
-To try it out, run the following commands:
+To try it out, run the following script:
 
 ```shell
-# Install the addon
-yarn add -D @storybook/addon-styling
-
 # Run the postinstall script from the root of your project
 node node_modules/@storybook/addon-styling/bin/postinstall.js
 ```

--- a/src/content/recipes/tailwindcss.md
+++ b/src/content/recipes/tailwindcss.md
@@ -26,7 +26,25 @@ In this post, we will:
 
 ![Finished example of Tailwind CSS in Storybook with a theme switcher](https://user-images.githubusercontent.com/18172605/208201389-1f448dbb-978c-442e-9d6b-7bf3fea63e64.gif)
 
-## Build Tailwind next to Storybook
+## Auto-config
+
+As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Tailwind.
+
+To try it out, run the following commands:
+
+```shell
+# Install the addon
+yarn add -D @storybook/addon-styling
+
+# Run the postinstall script from the root of your project
+node node_modules/@storybook/addon-styling/bin/postinstall.js
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
+
+## Manual
+
+### Build Tailwind next to Storybook
 
 To develop with Tailwind alongside your stories, storybook will need to know how to handle Tailwind's custom `@tailwind` css directive. We can do this with PostCSS.
 
@@ -72,7 +90,7 @@ module.exports = {
 
 **Note**: Using Vite, `@storybook/nextjs`, or `@storybook/preset-create-react-app` with `react-scripts@2.0.0` and up? You don't need to set `postCss` to true.
 
-## Provide Tailwind to stories
+### Provide Tailwind to stories
 
 Now you can import the `tailwind.css` file into your `.storybook/preview.js` file. This will make Tailwind’s style classes available to all of your stories.
 
@@ -104,7 +122,7 @@ To make use of Tailwind, replace the contents of each component file with the fo
 
 ![Storybook after adding tailwind CSS to the example components](https://user-images.githubusercontent.com/18172605/208201423-c7ea9392-1851-4fc3-9968-6d05399c2e91.gif)
 
-## Add a theme switcher tool
+### Add a theme switcher tool
 
 Tailwind comes out of the box with a light and dark theme. You can override those themes and add more. To get the most out of your stories, you should have a way to toggle between all of your themes.
 


### PR DESCRIPTION
Include instructions on how to run the codemod for `@storybook/addon-styling` in recipes of the tools supported.