### PR TITLE
Remove auto image center

### DIFF
--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -1,8 +1,8 @@
-import { styles } from '@storybook/design-system';
-import { css } from '@storybook/theming';
-import { darken, rgba } from 'polished';
+import { styles } from "@storybook/design-system";
+import { css } from "@storybook/theming";
+import { darken, rgba } from "polished";
 
-import { CODE_SNIPPET_CLASSNAME } from '../constants/code-snippets';
+import { CODE_SNIPPET_CLASSNAME } from "../constants/code-snippets";
 
 const { color, typography } = styles;
 
@@ -189,26 +189,6 @@ export const mdFormatting = css`
     display: block;
     padding: 0;
     max-width: 100%;
-    position: relative;
-    margin: 0 auto;
-
-    &.alignright {
-      float: right;
-      margin-right: 0;
-    }
-
-    &.alignleft {
-      float: left;
-      margin-left: 0;
-    }
-
-    &.aligncenter {
-      display: block;
-      margin-bottom: 1em;
-      margin-left: auto;
-      margin-right: auto;
-      margin-top: 1em;
-    }
   }
 
   .aside {

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -1,8 +1,8 @@
-import { styles } from "@storybook/design-system";
-import { css } from "@storybook/theming";
-import { darken, rgba } from "polished";
+import { styles } from '@storybook/design-system';
+import { css } from '@storybook/theming';
+import { darken, rgba } from 'polished';
 
-import { CODE_SNIPPET_CLASSNAME } from "../constants/code-snippets";
+import { CODE_SNIPPET_CLASSNAME } from '../constants/code-snippets';
 
 const { color, typography } = styles;
 


### PR DESCRIPTION
Closes #560 by removing opinionated styling rules that do not match GitHub's markdown styling