### PR TITLE
Append version tag to matched packages in snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
   "license": "MIT",
   "scripts": {
     "extract-monorepo-docs": "./scripts/extract-monorepo-docs.sh",
-    "prebuild": "yarn extract-monorepo-docs",
+    "append-package-tags-in-snippets": "node ./scripts/append-package-tags-in-snippets.js",
+    "prebuild": "yarn extract-monorepo-docs && yarn append-package-tags-in-snippets",
     "build": "gatsby build",
     "serve": "gatsby serve --prefix-paths",
     "develop": "gatsby develop -H 0.0.0.0",

--- a/scripts/append-package-tags-in-snippets.js
+++ b/scripts/append-package-tags-in-snippets.js
@@ -1,53 +1,94 @@
 const fs = require('fs');
+const { readdir } = require('fs').promises;
 const path = require('path');
 const versionData = require('../src/util/version-data');
 
 const { isPreRelease } = versionData;
 
-const FILE_FILTER = (file) =>
-  file.includes('.npm') ||
-  file.includes('.npx') ||
-  file.includes('.pnpm') ||
-  file.includes('.yarn');
+const DOCS_DIR = path.resolve(__dirname, '../src/content/docs');
 
-const snippetFiles = fs
-  .readdirSync(path.resolve(__dirname, '../src/content/docs/snippets/common'))
-  .filter(FILE_FILTER);
+const INLINE_CODE_REGEX = /`(?!`)(.*)`/g;
+const CODE_BLOCK_REGEX = /```(?:sh|shell|bash)\n\s*(?:#.*\n)?(.*)\n\s*```/g;
 
-const MATCH_LIST = (preRelease) => {
-  const tag = preRelease ? '@next' : '@latest';
+const INLINE_CODE_MATCH_LIST = (preRelease) => [
+  {
+    test: /(storybook)(?:@\w+)? (automigrate|babelrc|extract|init|migrate|upgrade)(?! --prerelease)/g,
+    replacer: `$1${preRelease ? '@next' : '@latest'} $2`,
+  },
+];
 
-  return [
-    // `storybook init` || `storybook upgrade` (but not `storybook upgrade --prerelease`)
-    {
-      test: /(storybook)(?:@.*)? (init|upgrade)(?! --prerelease)/,
-      replacer: `$1${tag} $2`,
-    },
-    // `@storybook/...`
-    {
-      test: /(@storybook\/(?:\w+-?)+)(?:@.*)?/g,
-      replacer: (_, pkg) => `${pkg}${tag}`,
-    },
-  ];
-};
+const CODE_BLOCK_MATCH_LIST = (preRelease) => [
+  ...INLINE_CODE_MATCH_LIST(preRelease),
+  {
+    test: /(@storybook\/(?:\w+-?)+)(?:@\w+)?/g,
+    replacer: (_, pkg) => `${pkg}${preRelease ? '@next' : ''}`,
+  },
+];
 
-function appendPackageTagsInSnippets(fileContents, preRelease) {
-  let updatedContents = fileContents;
+function updateSnippet(snippetSrc, isBlockCodeSnippet, preRelease) {
+  const matchList = isBlockCodeSnippet ? CODE_BLOCK_MATCH_LIST : INLINE_CODE_MATCH_LIST;
 
-  MATCH_LIST(preRelease).forEach(({ test, replacer }) => {
-    if (fileContents.match(test)) {
-      updatedContents = updatedContents.replace(test, replacer);
+  let updatedSnippetSrc = snippetSrc;
+
+  matchList(preRelease).forEach(({ test, replacer }) => {
+    if (snippetSrc.match(test)) {
+      updatedSnippetSrc = updatedSnippetSrc.replace(test, replacer);
     }
   });
+
+  return updatedSnippetSrc;
+}
+
+function updateFile(fileContents, preRelease) {
+  let updatedContents = fileContents;
+
+  const inlineCodeSnippets = (fileContents.match(INLINE_CODE_REGEX) || []).map((code) =>
+    code.replace(INLINE_CODE_REGEX, '$1')
+  );
+
+  if (inlineCodeSnippets.length > 0) {
+    inlineCodeSnippets.forEach((snippet) => {
+      const updatedSnippet = updateSnippet(snippet, false, preRelease);
+      updatedContents = updatedContents.replace(snippet, updatedSnippet);
+    });
+  }
+
+  const blockCodeSnippets = (fileContents.match(CODE_BLOCK_REGEX) || []).map((code) =>
+    code.replace(CODE_BLOCK_REGEX, '$1')
+  );
+
+  if (blockCodeSnippets.length > 0) {
+    blockCodeSnippets.forEach((snippet) => {
+      const updatedSnippet = updateSnippet(snippet, true, preRelease);
+      updatedContents = updatedContents.replace(snippet, updatedSnippet);
+    });
+  }
 
   return updatedContents;
 }
 
-snippetFiles.forEach((file) => {
-  const filePath = path.resolve(__dirname, '../src/content/docs/snippets/common', file);
-  const fileContents = fs.readFileSync(filePath, 'utf8');
-  const updatedContents = appendPackageTagsInSnippets(fileContents, isPreRelease);
-  fs.writeFileSync(filePath, updatedContents, 'utf8');
-});
+// https://stackoverflow.com/a/45130990
+async function getFiles(dir) {
+  const dirents = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    dirents.map((dirent) => {
+      const res = path.resolve(dir, dirent.name);
+      return dirent.isDirectory() ? getFiles(res) : res;
+    })
+  );
+  return Array.prototype.concat(...files);
+}
 
-module.exports = { appendPackageTagsInSnippets };
+(async () => {
+  const docsFiles = (await getFiles(DOCS_DIR)).filter(
+    (file) => file.endsWith('.md') || file.endsWith('.mdx')
+  );
+
+  docsFiles.forEach((file) => {
+    const fileContents = fs.readFileSync(file, 'utf8');
+    const updatedContents = updateFile(fileContents, isPreRelease);
+    fs.writeFileSync(file, updatedContents, 'utf8');
+  });
+})();
+
+module.exports = { updateFile, updateSnippet };

--- a/scripts/append-package-tags-in-snippets.js
+++ b/scripts/append-package-tags-in-snippets.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const versionData = require('../src/util/version-data');
+
+const { isPreRelease } = versionData;
+
+const FILE_FILTER = (file) =>
+  file.includes('.npm') ||
+  file.includes('.npx') ||
+  file.includes('.pnpm') ||
+  file.includes('.yarn');
+
+const snippetFiles = fs
+  .readdirSync(path.resolve(__dirname, '../src/content/docs/snippets/common'))
+  .filter(FILE_FILTER);
+
+const MATCH_LIST = (preRelease) => {
+  const tag = preRelease ? '@next' : '@latest';
+
+  return [
+    // `storybook init` || `storybook upgrade` (but not `storybook upgrade --prerelease`)
+    {
+      test: /(storybook)(?:@.*)? (init|upgrade)(?! --prerelease)/,
+      replacer: `$1${tag} $2`,
+    },
+    // `@storybook/...`
+    {
+      test: /(@storybook\/(?:\w+-?)+)(?:@.*)?/g,
+      replacer: (_, pkg) => `${pkg}${tag}`,
+    },
+  ];
+};
+
+function appendPackageTagsInSnippets(fileContents, preRelease) {
+  let updatedContents = fileContents;
+
+  MATCH_LIST(preRelease).forEach(({ test, replacer }) => {
+    if (fileContents.match(test)) {
+      updatedContents = updatedContents.replace(test, replacer);
+    }
+  });
+
+  return updatedContents;
+}
+
+snippetFiles.forEach((file) => {
+  const filePath = path.resolve(__dirname, '../src/content/docs/snippets/common', file);
+  const fileContents = fs.readFileSync(filePath, 'utf8');
+  const updatedContents = appendPackageTagsInSnippets(fileContents, isPreRelease);
+  fs.writeFileSync(filePath, updatedContents, 'utf8');
+});
+
+module.exports = { appendPackageTagsInSnippets };

--- a/scripts/append-package-tags-in-snippets.test.ts
+++ b/scripts/append-package-tags-in-snippets.test.ts
@@ -1,0 +1,129 @@
+const { appendPackageTagsInSnippets } = require('./append-package-tags-in-snippets');
+
+function makeFileContents(str) {
+  return `
+\`\`\`shell
+${str}
+\`\`\`
+`;
+}
+
+describe('appendPackageTagsInSnippets', () => {
+  it('matches desired patterns', () => {
+    expect(appendPackageTagsInSnippets(makeFileContents('npx storybook init')))
+      .toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      npx storybook@latest init
+      \`\`\`
+      "
+    `);
+    expect(appendPackageTagsInSnippets(makeFileContents('npx storybook upgrade')))
+      .toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      npx storybook@latest upgrade
+      \`\`\`
+      "
+    `);
+    expect(appendPackageTagsInSnippets(makeFileContents('yarn add -D @storybook/testing-library')))
+      .toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      yarn add -D @storybook/testing-library@latest
+      \`\`\`
+      "
+    `);
+  });
+  it('handles multiple matches', () => {
+    expect(
+      appendPackageTagsInSnippets(
+        makeFileContents(
+          'yarn add -D @storybook/testing-library @storybook/jest @storybook/addon-interactions'
+        )
+      )
+    ).toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      yarn add -D @storybook/testing-library@latest @storybook/jest@latest @storybook/addon-interactions@latest
+      \`\`\`
+      "
+    `);
+  });
+  it('does not match `npm run storybook` or `yarn storybook`', () => {
+    expect(appendPackageTagsInSnippets(makeFileContents('npm run storybook')))
+      .toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      npm run storybook
+      \`\`\`
+      "
+    `);
+    expect(appendPackageTagsInSnippets(makeFileContents('yarn storybook'))).toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      yarn storybook
+      \`\`\`
+      "
+    `);
+  });
+  it('does nothing for `storybook upgrade --prerelease`', () => {
+    expect(appendPackageTagsInSnippets(makeFileContents('npx storybook@next upgrade --prerelease')))
+      .toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      npx storybook@next upgrade --prerelease
+      \`\`\`
+      "
+    `);
+  });
+  it('appends the correct tag', () => {
+    expect(appendPackageTagsInSnippets(makeFileContents('npx storybook init'), true))
+      .toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      npx storybook@next init
+      \`\`\`
+      "
+    `);
+  });
+  it('Removes existing tags', () => {
+    expect(appendPackageTagsInSnippets(makeFileContents('npx storybook@latest init'), true))
+      .toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      npx storybook@next init
+      \`\`\`
+      "
+    `);
+    expect(appendPackageTagsInSnippets(makeFileContents('npx storybook@next init')))
+      .toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      npx storybook@latest init
+      \`\`\`
+      "
+    `);
+    expect(
+      appendPackageTagsInSnippets(
+        makeFileContents('yarn add -D @storybook/testing-library@latest'),
+        true
+      )
+    ).toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      yarn add -D @storybook/testing-library@next
+      \`\`\`
+      "
+    `);
+    expect(
+      appendPackageTagsInSnippets(makeFileContents('yarn add -D @storybook/testing-library@next'))
+    ).toMatchInlineSnapshot(`
+      "
+      \`\`\`shell
+      yarn add -D @storybook/testing-library@latest
+      \`\`\`
+      "
+    `);
+  });
+});

--- a/src/util/version-data.js
+++ b/src/util/version-data.js
@@ -15,4 +15,5 @@ module.exports = {
   latestVersion,
   latestVersionString,
   isLatest: version === latestVersion,
+  isPreRelease: version > latestVersion,
 };


### PR DESCRIPTION
Closes #532 

See tests for behavior details.

I also made a [demo PR](https://github.com/storybookjs/frontpage/pull/574), to provide a [diff of how the snippets will be changed](https://github.com/storybookjs/frontpage/pull/574/commits/df23a3b0f5bf4b22be746db3b2573e4ee6cbf72e) (when docs are preRelease).

### Before

````md
```sh
npx storybook init
```

```sh
npx storybook@next upgrade --prerelease
```

```sh
yarn add -D @storybook/testing-library @storybook/jest @storybook/addon-interactions
```

`npx storybook init`

`@storybook/testing-library`
````

### After

#### When building _latest_ docs

````md
```sh
npx storybook@latest init
```

<!-- Unchanged, because `--prerelease` flag should always be used with `@next` version -->
```sh
npx storybook@next upgrade --prerelease
```

<!-- Unchanged, because `@latest` is unnecessary here -->
```sh
yarn add -D @storybook/testing-library @storybook/jest @storybook/addon-interactions
```

`npx storybook@latest init`

<!-- Unchanged, because it's inline code and `@latest` is unnecessary here -->
`@storybook/testing-library`
````

#### When building _preRelease_ docs

````md
```sh
npx storybook@next init
```

<!-- Unchanged, because `--prerelease` flag should always be used with `@next` version -->
```sh
npx storybook@next upgrade --prerelease
```

```sh
yarn add -D @storybook/testing-library@next @storybook/jest@next @storybook/addon-interactions@next
```

`npx storybook@next init`

<!-- Unchanged, because it's inline code -->
`@storybook/testing-library`
````