### PR TITLE
Update recipes to add warning about codemod use

### DIFF
--- a/src/content/recipes/@emotion/styled.md
+++ b/src/content/recipes/@emotion/styled.md
@@ -37,7 +37,30 @@ Add the `@storybook/addon-styling` package to your DevDependencies
 yarn add -D @storybook/addon-styling
 ```
 
-Then register with Storybook in `.storybook/main.js`.
+## Auto-config
+
+<div class="aside">
+
+<span aria-hidden="true">📣</span> Before running this codemod, please ensure that you have no other changes in your git branch.
+
+</div>
+
+As of version 1.3, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Emotion.
+
+To try it out, run the following script:
+
+```shell
+# Run the postinstall script from the root of your project
+yarn addon-styling-setup
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the manual instructions below will get you up and running in no time.
+
+## Manual
+
+### Register the addon
+
+Register the addon with Storybook in `.storybook/main.js`.
 
 ```js
 module.exports = {
@@ -45,21 +68,6 @@ module.exports = {
   addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
 };
 ```
-
-## Auto-config
-
-As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Emotion.
-
-To try it out, run the following script:
-
-```shell
-# Run the postinstall script from the root of your project
-node node_modules/@storybook/addon-styling/bin/postinstall.js
-```
-
-If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
-
-## Manual
 
 ### How to setup `GlobalStyles`
 

--- a/src/content/recipes/@mui/material.md
+++ b/src/content/recipes/@mui/material.md
@@ -26,7 +26,30 @@ Add the `@storybook/addon-styling` package to your DevDependencies
 yarn add -D @storybook/addon-styling
 ```
 
-Then register with Storybook in `.storybook/main.js`.
+## Auto-config
+
+<div class="aside">
+
+<span aria-hidden="true">📣</span> Before running this codemod, please ensure that you have no other changes in your git branch.
+
+</div>
+
+As of version 1.3, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Material UI.
+
+To try it out, run the following script:
+
+```shell
+# Run the postinstall script from the root of your project
+yarn addon-styling-setup
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
+
+## Manual
+
+### Register the addon
+
+Register the addon with Storybook in `.storybook/main.js`.
 
 ```js
 module.exports = {
@@ -34,21 +57,6 @@ module.exports = {
   addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
 };
 ```
-
-## Auto-config
-
-As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Material UI.
-
-To try it out, run the following script:
-
-```shell
-# Run the postinstall script from the root of your project
-node node_modules/@storybook/addon-styling/bin/postinstall.js
-```
-
-If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
-
-## Manual
 
 ### Bundle fonts and icons for better perf
 

--- a/src/content/recipes/styled-components.md
+++ b/src/content/recipes/styled-components.md
@@ -36,7 +36,30 @@ Add the `@storybook/addon-styling` package to your DevDependencies
 yarn add -D @storybook/addon-styling
 ```
 
-Then register with Storybook in `.storybook/main.js`.
+## Auto-config
+
+<div class="aside">
+
+<span aria-hidden="true">📣</span> Before running this codemod, please ensure that you have no other changes in your git branch.
+
+</div>
+
+As of version 1.3, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with styled-components.
+
+To try it out, run the following script:
+
+```shell
+# Run the postinstall script from the root of your project
+yarn addon-styling-setup
+```
+
+If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
+
+## Manual
+
+### Register the addon
+
+Register the addon with Storybook in `.storybook/main.js`.
 
 ```js
 module.exports = {
@@ -44,21 +67,6 @@ module.exports = {
   addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
 };
 ```
-
-## Auto-config
-
-As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with styled-components.
-
-To try it out, run the following script:
-
-```shell
-# Run the postinstall script from the root of your project
-node node_modules/@storybook/addon-styling/bin/postinstall.js
-```
-
-If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
-
-## Manual
 
 ### How to setup `GlobalStyles`
 

--- a/src/content/recipes/tailwindcss.md
+++ b/src/content/recipes/tailwindcss.md
@@ -34,24 +34,21 @@ Add the `@storybook/addon-styling` package to your DevDependencies
 yarn add -D @storybook/addon-styling
 ```
 
-Then register with Storybook in `.storybook/main.js`.
-
-```js
-module.exports = {
-  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-styling'],
-};
-```
-
 ## Auto-config
 
-As of version 1.1, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Tailwind.
+<div class="aside">
+
+<span aria-hidden="true">📣</span> Before running this codemod, please ensure that you have no other changes in your git branch.
+
+</div>
+
+As of version 1.3, `@storybook/addon-styling` offers a codemod for to automatically configure your storybook with Tailwind.
 
 To try it out, run the following script:
 
 ```shell
 # Run the postinstall script from the root of your project
-node node_modules/@storybook/addon-styling/bin/postinstall.js
+yarn addon-styling-setup
 ```
 
 If the codemod didn't work, please let us know in [this GitHub issue](https://github.com/storybookjs/addon-styling/issues/49#issue-1746365130) so we can continue to make the codemod even better. In the meantime, the instructions below will get you up and running in no time.
@@ -81,7 +78,7 @@ module.exports = {
 };
 ```
 
-Then add the `@storybook/addon-styling` to your `.storybook/main.js` file with the `postCss` option set to true.
+Then add the `@storybook/addon-styling` to your `.storybook/main.js` file an pass it `postcss` in `options.postCss.implementation`.
 
 ```js
 module.exports = {
@@ -94,7 +91,9 @@ module.exports = {
       options: {
         // Check out https://github.com/storybookjs/addon-styling/blob/main/docs/api.md
         // For more details on this addon's options.
-        postCss: true,
+        postCss: {
+          implementation: require.resolve('postcss'),
+        },
       },
     },
   ],
@@ -102,7 +101,11 @@ module.exports = {
 };
 ```
 
-**Note**: Using Vite, `@storybook/nextjs`, or `@storybook/preset-create-react-app` with `react-scripts@2.0.0` and up? You don't need to set `postCss` to true.
+<div class="aside">
+
+<span aria-hidden="true">📣</span> If you are using Vite, `@storybook/nextjs`, `@storybook/angular`, or `@storybook/preset-create-react-app` with `react-scripts@2.0.0`, then leave the options object empty.
+
+</div>
 
 ### Provide Tailwind to stories
 

--- a/src/content/recipes/tailwindcss.md
+++ b/src/content/recipes/tailwindcss.md
@@ -103,7 +103,7 @@ module.exports = {
 
 <div class="aside">
 
-<span aria-hidden="true">📣</span> If you are using Vite, `@storybook/nextjs`, `@storybook/angular`, or `@storybook/preset-create-react-app` with `react-scripts@2.0.0`, then leave the options object empty.
+📣 If you are using Vite, `@storybook/nextjs`, `@storybook/angular`, or `@storybook/preset-create-react-app` with `react-scripts@2.0.0`, then leave the options object empty.
 
 </div>
 

--- a/src/content/recipes/tailwindcss.md
+++ b/src/content/recipes/tailwindcss.md
@@ -78,7 +78,7 @@ module.exports = {
 };
 ```
 
-Then add the `@storybook/addon-styling` to your `.storybook/main.js` file an pass it `postcss` in `options.postCss.implementation`.
+Then add the `@storybook/addon-styling` to your `.storybook/main.js` file and pass it `postcss` in `options.postCss.implementation`.
 
 ```js
 module.exports = {


### PR DESCRIPTION
## What changed

- Add warning to run codemod from a clean working tree
- Draw more attention to when you should avoid using the webpack configuration options in addon-styling