### PR TITLE
UI: Add params config to YoutubeCallout component

### DIFF
--- a/src/components/screens/DocsScreen/YouTubeCallout.stories.tsx
+++ b/src/components/screens/DocsScreen/YouTubeCallout.stories.tsx
@@ -39,3 +39,9 @@ InsideMdWrapper.decorators = [(storyFn) => <MDWrapper>{storyFn()}</MDWrapper>];
 export const InsideMdWrapperOpen = Template.bind({});
 InsideMdWrapperOpen.args = Open.args;
 InsideMdWrapperOpen.decorators = InsideMdWrapper.decorators;
+
+export const WithTimeStamp = Template.bind({});
+WithTimeStamp.args = {
+  ...Open.args,
+  params: 'start=84',
+};

--- a/src/components/screens/DocsScreen/YouTubeCallout.tsx
+++ b/src/components/screens/DocsScreen/YouTubeCallout.tsx
@@ -8,6 +8,7 @@ interface YouTubeCalloutProps {
   open?: boolean;
   summary?: string;
   title: string;
+  params?: string;
 }
 
 const { color, typography, spacing } = styles;
@@ -149,6 +150,7 @@ export const YouTubeCallout = ({
   open,
   summary = 'Watch a video tutorial on the Storybook channel',
   title,
+  params,
 }: YouTubeCalloutProps) => (
   <Details open={open}>
     <Summary>
@@ -156,6 +158,6 @@ export const YouTubeCallout = ({
       {summary}
       <Arrow />
     </Summary>
-    <LiteYouTubeEmbed id={id} title={title} />
+    <LiteYouTubeEmbed id={id} title={title} params={params} />
   </Details>
 );


### PR DESCRIPTION
With this pull request the YoutubeCallout component was expanded to feature a `params` option, giving us the option to link specific timestamps based on the underlying library used (i.e., `react-lite-youtube-embed`)

What was done:
- Updated the component
- Added example stories to test the implementation


If nothing arises, this should be merged ahead of the following documentation [pull request](https://github.com/storybookjs/storybook/pull/23797) to avoid issues.

@kylegach, when you have a moment, take a look and let me know of any feedback.

Appreciate it 🙏 