### PR TITLE
Add styles for H5 level headings

### DIFF
--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -85,6 +85,12 @@ export const mdFormatting = css`
     margin: 2rem 0 0.5rem;
   }
 
+  h5 {
+    font-size: ${typography.size.s2}px;
+    font-weight: ${typography.weight.bold};
+    margin: 2rem 0 0.5rem;
+  }
+
   p {
     margin: 1.5em 0;
     position: relative;


### PR DESCRIPTION
Necessary for complex API references, e.g. `main-config-indexers`:

![image](https://github.com/storybookjs/frontpage/assets/486540/7810be52-b79b-4b5d-8320-1c0787a1b482)

`IndexerOptions` is an H4; `makeTitle` is an H5.