### PR TITLE
Hide v8 from VersionSelector menu

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -165,9 +165,9 @@ module.exports = {
             'Access-Control-Allow-Origin: *',
             'Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept',
           ],
-          ...(!versionData.isLatest && {
-            [`/docs/${versionData.versionString}/*`]: ['X-Robots-Tag: noindex'],
-          }),
+          // ...(!versionData.isLatest && {
+          [`/docs/${versionData.versionString}/*`]: ['X-Robots-Tag: noindex'],
+          // }),
         },
         // Do not use the default security headers. Use those we have defined above.
         mergeSecurityHeaders: false,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -137,22 +137,27 @@ exports.createPages = ({ actions, graphql }) => {
             // Data passed to context is available in page queries as GraphQL variables.
             const context = { pageType, slug, version: releaseVersion };
 
-            createPage({
-              path: slug,
-              component: path.resolve(`./src/components/screens/ReleasesScreen/ReleasesScreen.js`),
-              context,
-            });
+            // TODO: Remove this condition once 8.0 has an actual pre-release
+            if (releaseVersion !== '8.0') {
+              createPage({
+                path: slug,
+                component: path.resolve(
+                  `./src/components/screens/ReleasesScreen/ReleasesScreen.js`
+                ),
+                context,
+              });
 
-            createPage({
-              path: iframeSlug,
-              component: path.resolve(
-                `./src/components/screens/ReleasesScreen/IframeReleasesScreen.js`
-              ),
-              context: {
-                ...context,
-                layout: 'iframe',
-              },
-            });
+              createPage({
+                path: iframeSlug,
+                component: path.resolve(
+                  `./src/components/screens/ReleasesScreen/IframeReleasesScreen.js`
+                ),
+                context: {
+                  ...context,
+                  layout: 'iframe',
+                },
+              });
+            }
           });
 
           frameworks = [...coreFrameworks, ...communityFrameworks];

--- a/src/components/screens/DocsScreen/VersionSelector.stories.tsx
+++ b/src/components/screens/DocsScreen/VersionSelector.stories.tsx
@@ -6,7 +6,13 @@ import { pageContext } from '../../layout/DocsLayout.stories';
 
 const { coreFrameworks } = require('../../../content/docs/frameworks');
 
-const { versions } = pageContext;
+const { versions: originalVersions } = pageContext;
+
+// TODO: Remove this once 8.0 has an actual pre-release
+const versions = {
+  ...originalVersions,
+  preRelease: [...originalVersions.preRelease, { version: 8, string: '8.0', label: 'future' }],
+};
 
 // The Wrapper helps capture the tooltip contents in the snapshot
 const Wrapper = styled.span`
@@ -58,3 +64,13 @@ NoPreReleases.args = {
   },
 };
 NoPreReleases.play = Base.play;
+
+export const OnlyV8PreRelease = Template.bind({});
+OnlyV8PreRelease.args = {
+  ...Base.args,
+  versions: {
+    ...versions,
+    preRelease: [{ version: 8, string: '8.0', label: 'future' }],
+  },
+};
+OnlyV8PreRelease.play = Base.play;

--- a/src/components/screens/DocsScreen/VersionSelector.tsx
+++ b/src/components/screens/DocsScreen/VersionSelector.tsx
@@ -30,7 +30,18 @@ interface VersionSelectorProps {
   versions: Versions;
 }
 
-export function VersionSelector({ framework, version, versions, slug }: VersionSelectorProps) {
+export function VersionSelector({
+  framework,
+  version,
+  versions: originalVersions,
+  slug,
+}: VersionSelectorProps) {
+  // TODO: Remove this once 8.0 has an actual pre-release
+  const versions = {
+    ...originalVersions,
+    preRelease: originalVersions.preRelease.filter(({ version: v }) => v !== 8),
+  };
+
   const getVersionLink = ({ label, string }: { label?: string; string: string }) => ({
     label: stylizeVersion({ label, string }),
     link: { url: buildPathWithFramework(slug, framework, string) },

--- a/src/components/screens/ReleasesScreen/ReleasesScreen.js
+++ b/src/components/screens/ReleasesScreen/ReleasesScreen.js
@@ -61,11 +61,14 @@ function ReleasesScreen({ data, ...props }) {
       fields: { slug: currentPageSlug },
     },
   } = data;
-  const tocEntries = edges.map(({ node }) => ({
-    path: node.fields.slug,
-    title: node.fields.version,
-    type: 'bullet-link',
-  }));
+  const tocEntries = edges
+    .map(({ node }) => ({
+      path: node.fields.slug,
+      title: node.fields.version,
+      type: 'bullet-link',
+    }))
+    // TODO: Remove this once 8.0 has an actual pre-release
+    .filter(({ title: t }) => t !== '8.0');
 
   return (
     <>

--- a/src/components/screens/ReleasesScreen/ReleasesScreen.stories.js
+++ b/src/components/screens/ReleasesScreen/ReleasesScreen.stories.js
@@ -26,6 +26,10 @@ const data = {
       {
         node: buildRelease('1.0'),
       },
+      // TODO: Remove this once 8.0 has an actual pre-release
+      {
+        node: buildRelease('8.0'),
+      },
     ],
   },
   currentPage,

--- a/src/content/releases/8.0.md
+++ b/src/content/releases/8.0.md
@@ -1,0 +1,4 @@
+---
+title: 'Storybook 8.0 - TBD'
+---
+


### PR DESCRIPTION
- For now, the v8 docs are only going to be published to provide permalinks. We don't want to expose the option in the menu.