### PR TITLE
Remove trending from catalog homepage

### DIFF
--- a/src/components/screens/IntegrationsCatalog/IntegrationsCatalogHomeScreen/IntegrationsCatalogHomeScreen.js
+++ b/src/components/screens/IntegrationsCatalog/IntegrationsCatalogHomeScreen/IntegrationsCatalogHomeScreen.js
@@ -99,7 +99,7 @@ const PopularRecipes = styled(RecipesList)`
 `;
 
 export const IntegrationsCatalogHomeScreen = ({
-  pageContext: { popularAddons = [], popularRecipes = [], trendingAddons = [], trendingTags = [] },
+  pageContext: { popularAddons = [], popularRecipes = [], trendingTags = [] },
 }) => {
   const { title, ogImageAddons, urls = {} } = useSiteMetadata();
   const { home } = urls;
@@ -131,8 +131,6 @@ export const IntegrationsCatalogHomeScreen = ({
           </ListHeadingContainer>
           <PopularRecipes recipeItems={popularRecipes} />
         </section>
-
-        <AddonsGrid title="Trending addons" addonItems={trendingAddons} />
       </IntegrationsLayout>
     </>
   );
@@ -142,7 +140,6 @@ IntegrationsCatalogHomeScreen.propTypes = {
   pageContext: PropTypes.shape({
     popularAddons: AddonsGrid.propTypes.addonItems.isRequired,
     popularRecipes: RecipesList.propTypes.recipeItems.isRequired,
-    trendingAddons: AddonsGrid.propTypes.addonItems.isRequired,
   }).isRequired,
 };
 

--- a/src/components/screens/IntegrationsCatalog/IntegrationsCatalogHomeScreen/IntegrationsCatalogHomeScreen.stories.js
+++ b/src/components/screens/IntegrationsCatalog/IntegrationsCatalogHomeScreen/IntegrationsCatalogHomeScreen.stories.js
@@ -22,7 +22,6 @@ const Template = () => (
     pageContext={{
       popularAddons: addonItemsData.slice(0, 6),
       popularRecipes: recipeItemsData.slice(0, 3),
-      trendingAddons: addonItemsData.slice(-9),
       trendingTags: [
         {
           link: '/notes',

--- a/src/util/create-integrations-pages/create-integrations-home-page.js
+++ b/src/util/create-integrations-pages/create-integrations-home-page.js
@@ -36,34 +36,12 @@ function fetchIntegrationsHomePage(createPage, graphql) {
                   }
                 }
               }
-              trending: topIntegrations(sort: trending, limit: 9) {
-                addons {
-                  ${ADDON_FRAGMENT}
-                  tags {
-                    name
-                    displayName
-                    description
-                    icon
-                  }
-                  repositoryUrl
-                  npmUrl
-                }
-                recipes {
-                  ${RECIPE_FRAGMENT}
-                  tags {
-                    name
-                    displayName
-                    description
-                    icon
-                  }
-                }
-              }
             }
           }
         `
       )
     )
-    .then(validateResponse((data) => data.integrations.popular && data.integrations.trending))
+    .then(validateResponse((data) => data.integrations.popular))
     .then(({ data }) => data.integrations)
     .then((integrationsData) => {
       generateIntegrationHomePage(createPage, integrationsData);
@@ -93,8 +71,8 @@ function getNRandomTags(tags, numberOfTags) {
     .map(({ occurrence, ...tag }) => tag);
 }
 
-function generateIntegrationHomePage(createPage, { popular, trending }) {
-  const tagOccurrences = createTagOccurrenceHash(...trending.addons, ...popular.addons);
+function generateIntegrationHomePage(createPage, { popular }) {
+  const tagOccurrences = createTagOccurrenceHash(...popular.addons);
 
   createPage({
     path: '/integrations/',
@@ -102,7 +80,6 @@ function generateIntegrationHomePage(createPage, { popular, trending }) {
     context: {
       popularAddons: popular.addons,
       popularRecipes: popular.recipes,
-      trendingAddons: trending.addons,
       trendingTags: getNRandomTags(tagOccurrences, 20),
     },
   });


### PR DESCRIPTION
Trending is currently filled with addons that are out of date and unmaintained.
We should hide them for now until we can curate our own list