### PR TITLE
Add GitHub Discussion links

### DIFF
--- a/src/components/screens/CommunityScreen/CommunitySupport.tsx
+++ b/src/components/screens/CommunityScreen/CommunitySupport.tsx
@@ -46,12 +46,12 @@ export const CommunitySupport = forwardRef<HTMLDivElement, CommunitySupportProps
         <SearchBlock version={version} apiKey={apiKey} />
         <SupportFeatureGrid>
           <SupportFeature
-            image={<DiscordIcon />}
-            title="Ask a question in #support chat"
-            desc="Resolve issues with community help. A maintainer is usually online."
+            image={<GithubIcon />}
+            title="Post a question in GitHub Discussions"
+            desc="Share your issues with our community and get help from other devs."
           >
-            <Link withArrow href={chatUrl}>
-              Chat now
+            <Link withArrow href="https://github.com/storybookjs/storybook/discussions">
+              View GitHub Discussions
             </Link>
           </SupportFeature>
           <SupportFeature
@@ -60,7 +60,7 @@ export const CommunitySupport = forwardRef<HTMLDivElement, CommunitySupportProps
             desc="Please report issues, someone else may have the same issue."
           >
             <Link withArrow href={repoUrl}>
-              View GitHub issues
+              View GitHub Issues
             </Link>
           </SupportFeature>
         </SupportFeatureGrid>

--- a/src/components/screens/IndexScreen/SocialValidation.js
+++ b/src/components/screens/IndexScreen/SocialValidation.js
@@ -231,7 +231,7 @@ export function SocialValidation({
         <SocialCard
           inverse
           icon={<ColoredIcon icon="discord" aria-label="Discord" color="#5A65EA" />}
-          description={`Get support and chat with ${discordMemberCount.toLocaleString()}+ frontend developers.`}
+          description={`Chat with ${discordMemberCount.toLocaleString()}+ frontend developers.`}
           link={{
             label: 'Join Discord server',
             href: 'https://discord.gg/storybook',
@@ -246,7 +246,7 @@ export function SocialValidation({
           icon={<ColoredIcon icon="twitter" aria-label="Twitter" color="#4999E9" />}
           description="Get the latest news and updates from Storybook maintainers."
           link={{
-            label: 'Follow on Twitter',
+            label: 'Follow on X',
             href: 'https://twitter.com/storybookjs',
           }}
           stat={{

--- a/src/components/screens/IndexScreen/SocialValidation.js
+++ b/src/components/screens/IndexScreen/SocialValidation.js
@@ -246,7 +246,7 @@ export function SocialValidation({
           icon={<ColoredIcon icon="twitter" aria-label="Twitter" color="#4999E9" />}
           description="Get the latest news and updates from Storybook maintainers."
           link={{
-            label: 'Follow on X',
+            label: 'Follow on Twitter',
             href: 'https://twitter.com/storybookjs',
           }}
           stat={{


### PR DESCRIPTION
**Note**: In the `CommunitySupport` component, I added a direct link to GH Discussions, _rather_ than editing the `ChatUrl` prop. That's because `ChatUrl` goes to Discord everywhere (I think?) and there are many places where we'll still want to keep the Discord link as it is.