### PR TITLE
Add sub-pages support to docs

### DIFF
--- a/src/components/screens/DocsScreen/DocsScreen.stories.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.stories.tsx
@@ -33,6 +33,14 @@ export default {
 
 export const Base = () => <DocsScreen data={data} pageContext={pageContext} location={location} />;
 
+export const WithSubPageTabs = () => (
+  <DocsScreen
+    data={data}
+    pageContext={{ ...pageContext, tabs: ['guide', 'api'], activeTab: 'guide' }}
+    location={location}
+  />
+);
+
 export const WithGuideLink = () => (
   <DocsScreen data={data} pageContext={{ ...pageContext, nextTocItem }} location={location} />
 );

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -1,31 +1,26 @@
 import React, { useMemo } from 'react';
-import { styled } from '@storybook/theming';
 import { MDXProvider } from '@mdx-js/react';
-import { MDXRenderer } from 'gatsby-plugin-mdx';
-import {
-  Button,
-  Highlight,
-  Link,
-  ShadowBoxCTA,
-  Subheading,
-  styles,
-} from '@storybook/design-system';
 import { graphql } from 'gatsby';
-import { CodeSnippets } from './CodeSnippets';
-import { rendererSupportsFeature, RendererSupportTable } from './RendererSupportTable';
-import { SocialGraph } from '../../basics';
-import { Callout } from '../../basics/Callout';
-import { Pre } from '../../basics/Pre';
-import GatsbyLinkWrapper from '../../basics/GatsbyLinkWrapper';
-import useSiteMetadata from '../../lib/useSiteMetadata';
+import { MDXRenderer } from 'gatsby-plugin-mdx';
+import { Button, Link, ShadowBoxCTA, Subheading, styles } from '@storybook/design-system';
+import { styled } from '@storybook/theming';
+
 import { mdFormatting } from '../../../styles/formatting';
 import buildPathWithVersion from '../../../util/build-path-with-version';
 import relativeToRootLinks from '../../../util/relative-to-root-links';
 import stylizeRenderer from '../../../util/stylize-renderer';
+import { SocialGraph } from '../../basics';
+import { Callout } from '../../basics/Callout';
+import GatsbyLinkWrapper from '../../basics/GatsbyLinkWrapper';
+import { Pre } from '../../basics/Pre';
+import useSiteMetadata from '../../lib/useSiteMetadata';
+import { CodeSnippets } from './CodeSnippets';
 import { useDocsContext } from './DocsContext';
+import { If } from './If';
 import { FeatureSnippets } from './FeatureSnippets';
 import { Feedback } from './Feedback';
-import { If } from './If';
+import { rendererSupportsFeature, RendererSupportTable } from './RendererSupportTable';
+import { SubPageTabs } from './SubPageTabs';
 import { YouTubeCallout } from './YouTubeCallout';
 
 const { color, spacing, typography } = styles;
@@ -116,7 +111,17 @@ function DocsScreen({ data, pageContext, location }) {
     urls: { homepageUrl },
     versionString,
   } = useSiteMetadata();
-  const { docsToc, fullPath, slug, tocItem, nextTocItem, isInstallPage } = pageContext;
+  const {
+    docsToc,
+    slugAsPath,
+    fullPath,
+    slug,
+    tocItem,
+    nextTocItem,
+    isInstallPage,
+    tabs,
+    activeTab,
+  } = pageContext;
 
   const {
     codeLanguage: [codeLanguage],
@@ -158,7 +163,7 @@ function DocsScreen({ data, pageContext, location }) {
   }, [renderer]);
 
   const features = featureGroups.flatMap((group) => group.features);
-  const feature = features.find((fs) => `/docs${fs.path}/` === slug);
+  const feature = features.find((fs) => `/docs${fs.path}/` === slugAsPath);
   const unsupported = feature && !rendererSupportsFeature(renderer, feature);
 
   let featureSupportItem;
@@ -209,6 +214,7 @@ function DocsScreen({ data, pageContext, location }) {
       <MDWrapper>
         {/* TODO: Renderer pills */}
         <Title>{isInstallPage ? `${title} for ${stylizeRenderer(renderer)}` : title}</Title>
+        {tabs && <SubPageTabs tabs={tabs} activeTab={activeTab} />}
         {unsupported && (
           <UnsupportedBanner>
             This feature is not supported in {stylizeRenderer(renderer)} yet. Help the open source
@@ -264,7 +270,7 @@ function DocsScreen({ data, pageContext, location }) {
         {tocItem && (
           <Feedback
             key={fullPath}
-            slug={slug}
+            slug={slugAsPath}
             version={versionString}
             renderer={renderer}
             codeLanguage={codeLanguage}

--- a/src/components/screens/DocsScreen/SubPageTabs.stories.tsx
+++ b/src/components/screens/DocsScreen/SubPageTabs.stories.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+
+import { SubPageTabs } from './SubPageTabs';
+
+type SubPageTabsProps = React.ComponentProps<typeof SubPageTabs>;
+
+const meta: Meta<SubPageTabsProps> = {
+  title: 'Screens/DocsScreen/SubPageTabs',
+  component: SubPageTabs,
+  args: {
+    tabs: ['guide', 'api'],
+    activeTab: 'guide',
+  },
+};
+export default meta;
+
+const Template: Story<SubPageTabsProps> = (args) => <SubPageTabs {...args} />;
+
+export const Default = Template.bind({});
+
+export const OtherTabSelected = Template.bind({});
+OtherTabSelected.args = {
+  activeTab: 'api',
+};
+
+export const Consistent = Template.bind({});
+Consistent.storyName = 'Consistent order and ignore unsupported ids';
+Consistent.args = {
+  tabs: ['guide', 'api', 'foo'],
+};

--- a/src/components/screens/DocsScreen/SubPageTabs.tsx
+++ b/src/components/screens/DocsScreen/SubPageTabs.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { css, styled } from '@storybook/theming';
+import { styles } from '@storybook/design-system';
+import GatsbyLink from '../../basics/GatsbyLink';
+
+import DOCS_TABS from '../../../constants/docs-tabs';
+
+const firstTabId = DOCS_TABS[0].id;
+
+const { code, color, spacing, typography } = styles;
+
+// TODO: Infer from DOCS_TABS
+type TabId = 'guide' | 'api';
+
+type SubPageTabsProps = {
+  tabs: TabId[];
+  activeTab: TabId;
+};
+
+const Tabs = styled.div`
+  border-bottom: 1px solid ${color.mediumlight};
+  display: flex;
+  font-size: ${typography.size.s2}px;
+  gap: ${spacing.padding.large}px;
+  margin-bottom: 1.5rem;
+`;
+
+type TabProps = React.ComponentProps<typeof GatsbyLink> & { isActive: boolean };
+
+const Tab = styled(GatsbyLink, {
+  shouldForwardProp: (prop) => !['isActive'].includes(prop),
+})<TabProps>`
+  padding: 0 ${spacing.padding.small}px ${spacing.padding.small}px;
+  position: relative;
+  bottom: -1px;
+
+  &&&:hover,
+  &&&:focus {
+    color: ${color.secondary};
+    transform: none;
+  }
+
+  ${({ isActive }) =>
+    isActive
+      ? css`
+          &&& {
+            border-bottom: 2px solid ${color.secondary};
+            color: ${color.secondary};
+            font-weight: ${typography.weight.bold};
+          }
+        `
+      : css`
+          &&& {
+            color: inherit;
+          }
+        `}
+`;
+
+function getHref(id: TabId, activeTab: TabId) {
+  if (activeTab === firstTabId) {
+    if (id !== firstTabId) {
+      return `./${id}`;
+    }
+  } else {
+    if (id === firstTabId) {
+      return '../';
+    }
+    if (id !== activeTab) {
+      return `../${id}`;
+    }
+  }
+  return './';
+}
+
+export const SubPageTabs = ({ tabs, activeTab }: SubPageTabsProps) => {
+  const relevantTabs = DOCS_TABS.filter(({ id }) => tabs.includes(id));
+
+  return (
+    <Tabs>
+      {relevantTabs.map(({ id, label }) => {
+        const isActive = id === activeTab;
+        return (
+          <Tab key={id} to={getHref(id, activeTab)} isActive={isActive} aria-current={isActive}>
+            {label}
+          </Tab>
+        );
+      })}
+    </Tabs>
+  );
+};

--- a/src/constants/docs-tabs.js
+++ b/src/constants/docs-tabs.js
@@ -1,0 +1,10 @@
+module.exports = [
+  {
+    id: 'guide',
+    label: 'Guide',
+  },
+  {
+    id: 'api',
+    label: 'API',
+  },
+];

--- a/src/util/add-state-to-toc.js
+++ b/src/util/add-state-to-toc.js
@@ -4,11 +4,18 @@ module.exports = function addStateToToc(items, pathPrefix = '/docs') {
   return items.map((item) => {
     const itemPath = item.pathSegment ? `${pathPrefix}/${item.pathSegment}` : pathPrefix;
 
+    let filePath = itemPath;
+    if (item.type === 'sub-page') {
+      // Translate from route path (with /) to file path (with .)
+      const subPagePath = itemPath.split('/').pop();
+      filePath = filePath.replace(`/${subPagePath}`, `.${subPagePath}`);
+    }
+
     return {
       ...item,
-      ...(item.type.match(/link/) && {
+      ...(item.type.match(/link|sub-page/) && {
         path: itemPath,
-        githubUrl: `${githubDocsBaseUrl}${itemPath}.md`,
+        githubUrl: `${githubDocsBaseUrl}${filePath}.md`,
       }),
       ...(item.children && { children: addStateToToc(item.children, itemPath) }),
     };


### PR DESCRIPTION
> [!WARNING]
> The approach in this PR _will not_ work. Translating from a single file, e.g. `parameters.api.md`, to a sub-route, e.g. `parameters/api` has significant consequences on parts of the frontpage architecture. Notably, the [`relative-to-root-links` functionality](https://github.com/storybookjs/frontpage/blob/main/src/util/relative-to-root-links.js) and the "Edit this page" GitHub link would both require major (if even possible) updates.
>
> I'll return to this with a new approach. At the moment, I'm thinking a fully 1:1 relationship between filesystem and routes. 🤔 

## What I did

- Adding a sub-page requires two steps:
    1. Add to TOC as sibling of parent page, e.g.
        ```js
        { pathSegment: 'parameters', title: 'Parameters', type: 'link', },
        // 👇 New sub-page
        { pathSegment: 'parameters/api', title: 'Parameters', type: 'sub-page', },
        ```
    2. Add a new file for the sub-page content, with a filename matching the sub-page id (the "api" part, above), e.g.
        `docs/writing-stories/parameters.api.md`
- Add SubPageTabs component
    - Add stories
    - Add to DocsScreen

<img width="989" alt="screenshot of Parameters guide page, showing Guide and API sub-page tabs" src="https://github.com/storybookjs/frontpage/assets/486540/51fc747a-812a-4109-aed1-47f7e6edfbca">

## How to test

_Because this depends on content updates, it cannot be previewed in a typical deploy preview. Instead I've made a demo branch which includes normally-ignored content changes._

**[Demo preview](https://deploy-preview-617--storybook-frontpage.netlify.app/docs/react/writing-stories/parameters)**

1. Confirm SubPageTabs component looks correct in Chromatic
1. Navigate to a page without sub-pages, e.g. [`/writing-stories/args`](https://deploy-preview-617--storybook-frontpage.netlify.app/docs/react/writing-stories/args)
    1. Confirm no tabs display
2. Navigate to a page with sub-pages, e.g. [`/writing-stories/parameters`](https://deploy-preview-617--storybook-frontpage.netlify.app/docs/react/writing-stories/parameters) (your only option for this demo)
    1. Confirm tabs display
    2. Confirm they are fully functional
3. Check the sitemaps
    1. Navigate to the [limited sitemap](https://deploy-preview-617--storybook-frontpage.netlify.app/sitemap/sitemap-0.xml) (used by search engines)
        1. Confirm both `/writing-stories/parameters` and `/writing-stories/parameters/api` are listed
    1. Navigate to the [full sitemap](https://deploy-preview-617--storybook-frontpage.netlify.app/sitemap-all/sitemap-0.xml) (used by Algolia for site search)
        1. Confirm both `/writing-stories/parameters` and `/writing-stories/parameters/api` are listed