### PR TITLE
Refactor RendererSelector to pill-based design

### DIFF
--- a/src/components/basics/Pill.stories.tsx
+++ b/src/components/basics/Pill.stories.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { styled } from '@storybook/theming';
+
+import { Pill } from './Pill';
+
+// Account for box-shadow on pills and height of open menu
+const Wrapper = styled.div`
+  min-height: 300px;
+  padding: 1px;
+`;
+
+export default {
+  title: 'Basics/Pill',
+  component: Pill,
+  args: {
+    children: 'Pill',
+  },
+  decorators: [(story) => <Wrapper>{story()}</Wrapper>],
+};
+
+export const Basic = {};
+
+export const Active = {
+  args: {
+    isActive: true,
+  },
+};

--- a/src/components/basics/Pill.tsx
+++ b/src/components/basics/Pill.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Button, color, fontWeight, typography, spacing } from '@chromaui/tetra';
+import { styled, css } from '@storybook/theming';
+
+export const pillStyles = css`
+  ${typography.body14}
+  border-radius: ${spacing[1]};
+  height: ${28 / 16}rem;
+  padding: 0 ${spacing[2]};
+  white-space: nowrap;
+
+  &:hover {
+    background-color: ${color.blueTr10};
+  }
+`;
+
+type PillProps = {
+  isActive?: boolean;
+};
+
+export const Pill = styled(({ isActive, ...props }) => (
+  <Button color={isActive ? 'blue' : 'slate'} size="sm" variant="outline" {...props} />
+))<PillProps>`
+  ${pillStyles}
+  ${({ isActive }) =>
+    isActive
+      ? css`
+          font-weight: ${fontWeight.bold};
+        `
+      : css`
+          color: ${color.slate800};
+        `}
+`;

--- a/src/components/screens/DocsScreen/DocsContext.tsx
+++ b/src/components/screens/DocsScreen/DocsContext.tsx
@@ -58,7 +58,8 @@ export function DocsContextProvider({
     let forcedRenderer = rendererProp;
     if (isBrowser) {
       const url = new URL(window.location.href);
-      forcedRenderer = url.searchParams.get(SEARCH_PARAMS_KEYS.RENDERER);
+      const rendererParam = url.searchParams.get(SEARCH_PARAMS_KEYS.RENDERER);
+      if (rendererParam) forcedRenderer = rendererParam;
 
       // Remove search param from URL, to allow selecting a different renderer
       url.searchParams.delete(SEARCH_PARAMS_KEYS.RENDERER);

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -27,6 +27,7 @@ import { FeatureSnippets } from './FeatureSnippets';
 import { Feedback } from './Feedback';
 import { If } from './If';
 import { YouTubeCallout } from './YouTubeCallout';
+import { RendererSelector } from './RendererSelector';
 
 const { color, spacing, typography } = styles;
 
@@ -207,8 +208,8 @@ function DocsScreen({ data, pageContext, location }) {
       <SocialGraph url={`${homepageUrl}${fullPath}/`} title={title} desc={description} />
 
       <MDWrapper>
-        {/* TODO: Renderer pills */}
         <Title>{isInstallPage ? `${title} for ${stylizeRenderer(renderer)}` : title}</Title>
+        <RendererSelector coreRenderers={coreRenderers} communityRenderers={communityRenderers} />
         {unsupported && (
           <UnsupportedBanner>
             This feature is not supported in {stylizeRenderer(renderer)} yet. Help the open source

--- a/src/components/screens/DocsScreen/RendererSelector.stories.tsx
+++ b/src/components/screens/DocsScreen/RendererSelector.stories.tsx
@@ -77,3 +77,14 @@ SelectACommunityRenderer.play = async (context) => {
 
   await userEvent.click(html);
 };
+
+export const NarrowScreen = Template.bind({});
+NarrowScreen.parameters = {
+  chromatic: { viewports: [320] },
+  viewport: { defaultViewport: 'smallMobile' },
+};
+
+export const NarrowScreenCommunityRendererSelected = Template.bind({});
+NarrowScreenCommunityRendererSelected.parameters = NarrowScreen.parameters;
+NarrowScreenCommunityRendererSelected.args = CommunityRendererSelected.args;
+NarrowScreenCommunityRendererSelected.play = Base.play;

--- a/src/components/screens/DocsScreen/RendererSelector.tsx
+++ b/src/components/screens/DocsScreen/RendererSelector.tsx
@@ -1,83 +1,209 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { styled } from '@storybook/theming';
-import { Menu } from '@storybook/components-marketing';
+import * as React from 'react';
+import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
+import { Button, Icon, color, fontWeight, typography, spacing } from '@chromaui/tetra';
+import { styled, css } from '@storybook/theming';
 
 import stylizeRenderer from '../../../util/stylize-renderer';
 import { useDocsContext } from './DocsContext';
 
-interface RendererSelectorProps {
-  coreRenderers: string[];
-  communityRenderers: string[];
+const Root = styled.div`
+  display: flex;
+  gap: ${spacing[2]};
+  margin-bottom: ${spacing[8]};
+`;
+
+const pillStyles = css`
+  ${typography.body14}
+  border-radius: ${spacing[1]};
+  height: ${28 / 16}rem;
+  padding: 0 ${spacing[2]};
+  white-space: nowrap;
+
+  &:hover {
+    background-color: ${color.blueTr10};
+  }
+`;
+
+const Pill = styled(({ isActive, ...props }) => (
+  <Button color={isActive ? 'blue' : 'slate'} size="sm" variant="outline" {...props} />
+))<{
+  isActive?: boolean;
+}>`
+  ${pillStyles}
+  ${({ isActive }) =>
+    isActive
+      ? css`
+          font-weight: ${fontWeight.bold};
+        `
+      : css`
+          color: ${color.slate800};
+        `}
+`;
+
+/**
+ * This portion is copied from Tetra's NavDropdownMenu.
+ * Notably:
+ * - Styles for TriggerButton match Pill
+ * - Menu items are not links
+ */
+
+const TriggerButton = styled(RadixDropdownMenu.Trigger, {
+  shouldForwardProp: (propName) => !['isActive', 'variant'].includes(propName),
+})<{
+  variant?: 'light' | 'dark';
+  isActive?: boolean;
+}>`
+  all: unset;
+  ${pillStyles}
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+  user-select: none;
+  border: none;
+  background: transparent;
+  box-shadow: 0 0 0 1px ${color.slate400};
+  gap: 6px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
+
+  &[data-state='open'] {
+    background-color: ${color.blueTr10};
+  }
+
+  &[data-state='open'] > .CaretDown {
+    transform: rotate(-180deg) translateY(0px);
+  }
+`;
+
+const CaretDown = styled.div`
+  position: relative;
+  transform: translateY(2px);
+  transition: transform 250ms ease;
+`;
+
+interface MenuTriggerProps {
+  variant?: 'light' | 'dark';
+  children?: React.ReactNode;
 }
 
-const RendererLogo = styled.img`
-  width: 12;
-  height: 12;
+export const MenuTrigger: React.FC<MenuTriggerProps> = ({ children, variant = 'light' }) => {
+  return (
+    <>
+      <TriggerButton variant={variant}>
+        {children}
+        <CaretDown className="CaretDown">
+          <Icon name="arrowdown" aria-hidden size={12} />
+        </CaretDown>
+      </TriggerButton>
+    </>
+  );
+};
+
+const MenuContent = styled(RadixDropdownMenu.Content)`
+  margin: 0;
+  background: ${color.white};
+  border-radius: 4px;
+  padding: ${spacing[2]};
+
+  box-shadow: 0px 0px 15px ${color.blackTr05}, 0px 1px 2px ${color.blackTr10};
 `;
 
-const MenuButton = styled.button`
-  appearance: none;
-  background: none;
-  border: 0;
+const MenuItem = styled(RadixDropdownMenu.Item)`
+  ${typography.body14};
+  color: ${color.slate800};
   cursor: pointer;
-  text-align: left;
-  width: 100%;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: ${spacing[2]};
+  border-radius: 4px;
+
+  &[data-highlighted] {
+    box-shadow: inset 0 0 0 2px rgba(30, 167, 253, 0.3);
+    background-color: ${color.blue100};
+    outline: none;
+  }
 `;
 
-type LinkWrapperProps = {
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+interface IMenuItem {
+  id: string;
+  label: string;
+  onClick: () => void;
+}
+
+interface MenuProps {
+  variant?: 'light' | 'dark';
+  label: string;
+  items: IMenuItem[];
+}
+
+const Menu = ({ label, variant, items, ...props }: MenuProps) => {
+  return (
+    <RadixDropdownMenu.Root>
+      <MenuTrigger variant={variant}>{label}</MenuTrigger>
+
+      <RadixDropdownMenu.Portal>
+        <MenuContent loop align="start" sideOffset={8}>
+          {items.map((item) => (
+            <MenuItem key={item.id} onSelect={item.onClick}>
+              {item.label}
+            </MenuItem>
+          ))}
+        </MenuContent>
+      </RadixDropdownMenu.Portal>
+    </RadixDropdownMenu.Root>
+  );
 };
 
-const getRendererLogo = (renderer) => {
-  if (renderer === 'rax') return '/renderers/logo-rax.png';
-  return `/renderers/logo-${renderer}.svg`;
+/** END NavDropdownMenu */
+
+type RendererSelectorProps = {
+  coreRenderers: string[];
+  communityRenderers: string[];
 };
 
-export function RendererSelector({ coreRenderers, communityRenderers }: RendererSelectorProps) {
-  const renderers = [...coreRenderers, ...communityRenderers] as const;
-
-  // TODO: How to access framework in localStorage
+export const RendererSelector = ({ coreRenderers, communityRenderers }: RendererSelectorProps) => {
   const {
     renderer: [renderer, setRenderer],
   } = useDocsContext();
 
-  const items = renderers.map((r) => ({
-    link: {
-      linkWrapper: React.forwardRef<HTMLButtonElement, LinkWrapperProps>(
-        ({ onClick, ...props }, ref) => {
-          return (
-            <MenuButton
-              onClick={(event) => {
-                setRenderer(r);
-                onClick?.(event);
-              }}
-              ref={ref}
-              {...props}
-            />
-          );
-        }
-      ),
-      url: 'UNUSED', // We render a `button` instead of an `a`, but the types of Menu require this
-    },
-    renderer: r,
-    icon: <RendererLogo src={getRendererLogo(r)} alt="" />,
-    label: stylizeRenderer(r),
-  }));
+  const pillItems = coreRenderers.slice();
+  const menuItems = communityRenderers.slice();
 
-  const coreItems = items.filter(({ renderer: r }) => coreRenderers.includes(r));
-  const communityItems = items.filter(({ renderer: r }) => !coreRenderers.includes(r));
+  if (menuItems.includes(renderer)) {
+    // Remove the last pill item and store it
+    const lastPillItem = pillItems.pop();
 
-  const rendererOptions = [
-    {
-      label: 'Core',
-      items: coreItems,
-    },
-    {
-      label: 'Community',
-      items: communityItems,
-    },
-  ];
+    // Add the current renderer on the end of pillRenderers
+    pillItems.push(renderer);
 
-  return <Menu label={stylizeRenderer(renderer)} items={rendererOptions} primary />;
-}
+    // Remove the current renderer from the menu
+    menuItems.splice(menuItems.indexOf(renderer), 1);
+
+    // Add the last pill item to the start of the menu
+    menuItems.unshift(lastPillItem);
+  }
+
+  return (
+    <Root>
+      {pillItems.map((r) => (
+        <Pill key={r} isActive={r === renderer} onClick={() => setRenderer(r)}>
+          {stylizeRenderer(r)}
+        </Pill>
+      ))}
+      <Menu
+        items={menuItems.map((r) => ({
+          id: r,
+          label: stylizeRenderer(r),
+          onClick: () => {
+            setRenderer(r);
+          },
+        }))}
+        label="More"
+      />
+    </Root>
+  );
+};

--- a/src/components/screens/DocsScreen/RendererSelector.tsx
+++ b/src/components/screens/DocsScreen/RendererSelector.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Button, Icon, color, fontWeight, typography, spacing } from '@chromaui/tetra';
+import { Button, Icon, breakpoint, color, fontWeight, typography, spacing } from '@chromaui/tetra';
 import { styled, css } from '@storybook/theming';
 
 import stylizeRenderer from '../../../util/stylize-renderer';
+import { useMediaQuery } from '../../lib/useMediaQuery';
 import { useDocsContext } from './DocsContext';
 
 const Root = styled.div`
@@ -172,6 +173,16 @@ export const RendererSelector = ({ coreRenderers, communityRenderers }: Renderer
 
   const pillItems = coreRenderers.slice();
   const menuItems = communityRenderers.slice();
+
+  const [narrow] = useMediaQuery(`(max-width: ${breakpoint.sm * (2 / 3)}px)`);
+
+  if (narrow) {
+    // Remove the last pill item and store it
+    const lastPillItem = pillItems.pop();
+
+    // Add the last pill item to the start of the menu
+    menuItems.unshift(lastPillItem);
+  }
 
   if (menuItems.includes(renderer)) {
     // Remove the last pill item and store it

--- a/src/components/screens/DocsScreen/RendererSelector.tsx
+++ b/src/components/screens/DocsScreen/RendererSelector.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Button, Icon, breakpoint, color, fontWeight, typography, spacing } from '@chromaui/tetra';
-import { styled, css } from '@storybook/theming';
+import { Icon, breakpoint, color, typography, spacing } from '@chromaui/tetra';
+import { styled } from '@storybook/theming';
 
 import stylizeRenderer from '../../../util/stylize-renderer';
+import { Pill, pillStyles } from '../../basics/Pill';
 import { useMediaQuery } from '../../lib/useMediaQuery';
 import { useDocsContext } from './DocsContext';
 
@@ -11,34 +12,6 @@ const Root = styled.div`
   display: flex;
   gap: ${spacing[2]};
   margin-bottom: ${spacing[8]};
-`;
-
-const pillStyles = css`
-  ${typography.body14}
-  border-radius: ${spacing[1]};
-  height: ${28 / 16}rem;
-  padding: 0 ${spacing[2]};
-  white-space: nowrap;
-
-  &:hover {
-    background-color: ${color.blueTr10};
-  }
-`;
-
-const Pill = styled(({ isActive, ...props }) => (
-  <Button color={isActive ? 'blue' : 'slate'} size="sm" variant="outline" {...props} />
-))<{
-  isActive?: boolean;
-}>`
-  ${pillStyles}
-  ${({ isActive }) =>
-    isActive
-      ? css`
-          font-weight: ${fontWeight.bold};
-        `
-      : css`
-          color: ${color.slate800};
-        `}
 `;
 
 /**


### PR DESCRIPTION
<img width="701" alt="Screenshot of pill-based design for selecting a renderer" src="https://github.com/storybookjs/frontpage/assets/486540/c9b35a0f-1d32-4a85-b129-15853942dfc9">

### How to test

1. Open [the deploy preview](https://deploy-preview-624--storybook-frontpage.netlify.app/docs/writing-stories/decorators)
    1. Confirm that the pills + menu look and feel correct
    1. Confirm that it is highlighting the correct renderer
    1. Confirm that you can choose another _core_ renderer (React, Vue, Angular, Web Components)
    1. Confirm that you can choose a _community_ renderer (under the More menu)
        1. Confirm that your selected community renderer has taken the place of the last pill (Web Components)
        1. Confirm that the last pill is now first in the More menu
        1. Confirm that your selected community renderer is not in the menu
    1. Confirm that you can select a _core_ renderer when a _community_ renderer is highlighted
        1. Confirm that all of the pill + menu manipulation from the previous step is now undone