### PR TITLE
Add "On this page" TOC

### DIFF
--- a/src/components/basics/InPageTOC.stories.tsx
+++ b/src/components/basics/InPageTOC.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { userEvent, within } from '@storybook/testing-library';
 import { InPageTOC } from './InPageTOC';
 
 const mockTOCItems = [
@@ -67,18 +66,3 @@ export default meta;
 const Template = (args) => <InPageTOC {...args} />;
 
 export const Basic = Template.bind({});
-
-export const Collapsed = Template.bind({});
-Collapsed.args = {
-  collapsed: true,
-};
-
-export const Open = Template.bind({});
-Open.args = Collapsed.args;
-Open.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-
-  const summary = canvas.getByText('On this page');
-
-  await userEvent.click(summary);
-};

--- a/src/components/basics/InPageTOC.stories.tsx
+++ b/src/components/basics/InPageTOC.stories.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+import { userEvent, within } from '@storybook/testing-library';
+import { InPageTOC } from './InPageTOC';
+
+const mockTOCItems = [
+  {
+    title: 'Level 2',
+    url: '#level-2',
+    items: [
+      {
+        title: 'Level 3',
+        url: '#level-3',
+      },
+      {
+        title: 'Level 3',
+        url: '#level-3',
+      },
+    ],
+  },
+  {
+    title: 'Level 2',
+    url: '#level-2',
+    items: [
+      {
+        title: 'Level 3',
+        url: '#level-3',
+        items: [
+          {
+            title: 'Level 4',
+            url: '#level-4',
+          },
+          {
+            title: 'Level 4',
+            url: '#level-4',
+          },
+        ],
+      },
+      {
+        title: 'Level 3',
+        url: '#level-3',
+      },
+    ],
+  },
+  {
+    title: 'Level 2',
+    url: '#level-2',
+  },
+  {
+    title: 'Level 2',
+    url: '#level-2',
+  },
+];
+
+const meta = {
+  title: 'Basics/InPageTOC',
+  component: InPageTOC,
+  args: {
+    items: mockTOCItems,
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+export default meta;
+
+const Template = (args) => <InPageTOC {...args} />;
+
+export const Basic = Template.bind({});
+
+export const Collapsed = Template.bind({});
+Collapsed.args = {
+  collapsed: true,
+};
+
+export const Open = Template.bind({});
+Open.args = Collapsed.args;
+Open.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  const summary = canvas.getByText('On this page');
+
+  await userEvent.click(summary);
+};

--- a/src/components/basics/InPageTOC.tsx
+++ b/src/components/basics/InPageTOC.tsx
@@ -1,48 +1,9 @@
 import * as React from 'react';
 import { styled } from '@storybook/theming';
-import { ChevronSmallDownIcon } from '@storybook/icons';
-import { color, fontFamily, spacing, Text } from '@chromaui/tetra';
+import { color, spacing, Text } from '@chromaui/tetra';
 
 const Heading = styled((props) => <Text as="h2" variant="heading16" {...props} />)`
   margin-bottom: ${spacing[3]};
-`;
-
-const Summary = styled.summary`
-  border: 0;
-  border-radius: ${spacing[1]};
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 0.5rem;
-  margin-left: -0.5rem;
-  background: transparent;
-  color: ${color.slate500};
-  height: 1.75rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-  font-family: ${fontFamily.sans};
-  gap: 0.375rem;
-  transition: all 0.16s ease-in-out;
-
-  &:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-
-  [open] > & {
-    margin-bottom: ${spacing[3]};
-
-    & > .CaretDown {
-      transform: rotate(-180deg) translateY(0px);
-    }
-  }
-`;
-
-const CaretDown = styled.div`
-  position: relative;
-  width: 14px;
-  height: 14px;
-  transition: transform 250ms ease;
 `;
 
 const List = styled.ol`
@@ -77,12 +38,12 @@ type Item = {
 };
 
 type InPageTOCProps = {
-  collapsed?: boolean;
   items: Item[];
 };
 
-export const InPageTOC = ({ collapsed, items }: InPageTOCProps) => {
-  const toc = (
+export const InPageTOC = ({ items }: InPageTOCProps) => (
+  <>
+    <Heading>On this page</Heading>
     <List>
       {items.map((h2Item) => (
         <TOCItem key={h2Item.title}>
@@ -108,22 +69,5 @@ export const InPageTOC = ({ collapsed, items }: InPageTOCProps) => {
         </TOCItem>
       ))}
     </List>
-  );
-
-  return collapsed ? (
-    <details>
-      <Summary>
-        On this page
-        <CaretDown className="CaretDown">
-          <ChevronSmallDownIcon aria-hidden />
-        </CaretDown>
-      </Summary>
-      {toc}
-    </details>
-  ) : (
-    <>
-      <Heading>On this page</Heading>
-      {toc}
-    </>
-  );
-};
+  </>
+);

--- a/src/components/basics/InPageTOC.tsx
+++ b/src/components/basics/InPageTOC.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { styled } from '@storybook/theming';
+import { ChevronSmallDownIcon } from '@storybook/icons';
+import { color, fontFamily, spacing, Text } from '@chromaui/tetra';
+
+const Heading = styled((props) => <Text as="h2" variant="heading16" {...props} />)`
+  margin-bottom: ${spacing[3]};
+`;
+
+const Summary = styled.summary`
+  border: 0;
+  border-radius: ${spacing[1]};
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.5rem;
+  margin-left: -0.5rem;
+  background: transparent;
+  color: ${color.slate500};
+  height: 1.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-family: ${fontFamily.sans};
+  gap: 0.375rem;
+  transition: all 0.16s ease-in-out;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  [open] > & {
+    margin-bottom: ${spacing[3]};
+
+    & > .CaretDown {
+      transform: rotate(-180deg) translateY(0px);
+    }
+  }
+`;
+
+const CaretDown = styled.div`
+  position: relative;
+  width: 14px;
+  height: 14px;
+  transition: transform 250ms ease;
+`;
+
+const List = styled.ol`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  ol & {
+    margin-top: ${spacing[3]};
+    margin-left: ${spacing[4]};
+  }
+`;
+
+const TOCItem = styled((props) => <Text as="li" variant="body14" {...props} />)`
+  margin-bottom: ${spacing[3]};
+
+  & > a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      color: ${color.blue500};
+      text-decoration: underline;
+    }
+  }
+`;
+
+type Item = {
+  title: string;
+  url: string;
+  items?: Item[];
+};
+
+type InPageTOCProps = {
+  collapsed?: boolean;
+  items: Item[];
+};
+
+export const InPageTOC = ({ collapsed, items }: InPageTOCProps) => {
+  const toc = (
+    <List>
+      {items.map((h2Item) => (
+        <TOCItem key={h2Item.title}>
+          <a href={h2Item.url}>{h2Item.title}</a>
+          {h2Item.items ? (
+            <List>
+              {h2Item.items.map((h3Item) => (
+                <TOCItem key={h3Item.title}>
+                  <a href={h3Item.url}>{h3Item.title}</a>
+                  {h3Item.items ? (
+                    <List>
+                      {h3Item.items.map((h4Item) => (
+                        <TOCItem key={h4Item.title}>
+                          <a href={h4Item.url}>{h4Item.title}</a>
+                        </TOCItem>
+                      ))}
+                    </List>
+                  ) : null}
+                </TOCItem>
+              ))}
+            </List>
+          ) : null}
+        </TOCItem>
+      ))}
+    </List>
+  );
+
+  return collapsed ? (
+    <details>
+      <Summary>
+        On this page
+        <CaretDown className="CaretDown">
+          <ChevronSmallDownIcon aria-hidden />
+        </CaretDown>
+      </Summary>
+      {toc}
+    </details>
+  ) : (
+    <>
+      <Heading>On this page</Heading>
+      {toc}
+    </>
+  );
+};

--- a/src/components/layout/DocsLayout.tsx
+++ b/src/components/layout/DocsLayout.tsx
@@ -91,6 +91,7 @@ const ScrollAreaThumb = styled(ScrollArea.Thumb)`
 
 const Content = styled.div`
   flex: 1;
+  min-width: 0;
   padding-top: 24px;
   padding-bottom: 24px;
 

--- a/src/components/screens/DocsScreen/DocsScreen.stories.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.stories.tsx
@@ -63,3 +63,47 @@ export const WithGithubLinkAndGuideLink = () => (
     location={location}
   />
 );
+
+export const WithoutTableOfContents = () => (
+  <DocsScreen
+    data={{
+      currentPage: {
+        ...data.currentPage,
+        tableOfContents: {
+          items: [
+            { title: 'Here is a level 2 heading', url: '#Here-is-a-level-2-heading' },
+            { title: 'Here is a level 3 heading', url: '#Here-is-a-level-3-heading' },
+            { title: 'Here is a level 4 heading', url: '#Here-is-a-level-4-heading' },
+          ],
+        },
+      },
+    }}
+    pageContext={pageContext}
+    location={location}
+  />
+);
+
+export const WithTableOfContents = () => (
+  <DocsScreen
+    data={{
+      currentPage: {
+        ...data.currentPage,
+        tableOfContents: {
+          items: [
+            { title: 'Here is a level 2 heading', url: '#Here-is-a-level-2-heading' },
+            { title: 'Here is a level 3 heading', url: '#Here-is-a-level-3-heading' },
+            { title: 'Here is a level 4 heading', url: '#Here-is-a-level-4-heading' },
+            { title: 'Here is a level 4 heading', url: '#Here-is-a-level-4-heading' },
+          ],
+        },
+      },
+    }}
+    pageContext={pageContext}
+    location={location}
+  />
+);
+WithTableOfContents.parameters = {
+  chromatic: {
+    viewports: [400, 1400],
+  },
+};

--- a/src/components/screens/DocsScreen/DocsScreen.stories.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { styled } from '@storybook/theming';
 
-import DocsScreen from './DocsScreen';
+import DocsScreen, { IS_2_COL_BREAKPOINT } from './DocsScreen';
 import compiledMDX from '../../../../.storybook/compiled-mdx';
 import { pageContext } from '../../layout/DocsLayout.stories';
 
@@ -104,6 +104,6 @@ export const WithTableOfContents = () => (
 );
 WithTableOfContents.parameters = {
   chromatic: {
-    viewports: [400, 1400],
+    viewports: [400, IS_2_COL_BREAKPOINT],
   },
 };

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -1,15 +1,20 @@
 import React, { useMemo } from 'react';
-import { styled } from '@storybook/theming';
+import { graphql } from 'gatsby';
+import { styled, css } from '@storybook/theming';
 import { MDXProvider } from '@mdx-js/react';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
+import { color, spacing } from '@chromaui/tetra';
 import { Button, Link, ShadowBoxCTA, Subheading, styles } from '@storybook/design-system';
-import { graphql } from 'gatsby';
+import * as ScrollArea from '@radix-ui/react-scroll-area';
+
 import { CodeSnippets } from './CodeSnippets';
 import { rendererSupportsFeature, RendererSupportTable } from './RendererSupportTable';
 import { SocialGraph } from '../../basics';
 import { Callout } from '../../basics/Callout';
+import { InPageTOC } from '../../basics/InPageTOC';
 import { Pre } from '../../basics/Pre';
 import GatsbyLinkWrapper from '../../basics/GatsbyLinkWrapper';
+import { useMediaQuery } from '../../lib/useMediaQuery';
 import useSiteMetadata from '../../lib/useSiteMetadata';
 import { mdFormatting } from '../../../styles/formatting';
 import buildPathWithVersion from '../../../util/build-path-with-version';
@@ -19,20 +24,123 @@ import { useDocsContext } from './DocsContext';
 import { FeatureSnippets } from './FeatureSnippets';
 import { Feedback } from './Feedback';
 import { If } from './If';
-import { YouTubeCallout } from './YouTubeCallout';
 import { RendererSelector } from './RendererSelector';
+import { YouTubeCallout } from './YouTubeCallout';
 
-const { color, spacing, typography } = styles;
+const { color: dsColor, spacing: dsSpacing, typography } = styles;
 
-const Title = styled.h1``;
+const MIN_HEADINGS_COUNT_FOR_TOC = 3;
+
+/**
+ * TODO: This breakpoint is a compromise:
+ * - Nav from `components-marketing` and `Container` from `tetra` both apply a bigger margin at
+ *   wider viewports, which results in a too narrow overall available width
+ * - That worked fine for a 1-col content layout, but does not work for a 2-col layout
+ */
+const IS_2_COL_BREAKPOINT = 1400;
+
+// Magic number to account for PageLayout header height
+const IN_PAGE_TOC_TOP_OFFSET = 112;
+
+const Root = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'hasRightRail',
+})<{ hasRightRail: boolean }>`
+  ${({ hasRightRail }) =>
+    hasRightRail &&
+    css`
+      @media (min-width: ${IS_2_COL_BREAKPOINT}px) {
+        display: grid;
+        grid-template-columns: 1fr 240px;
+        grid-template-rows: repeat(2, min-content);
+        grid-column-gap: ${spacing[8]};
+      }
+    `}
+`;
+
+const Header = styled.div`
+  grid-area: 1 / 1 / 2 / 2;
+  margin-bottom: ${spacing[8]};
+`;
+
+const RightRail = styled.div`
+  margin-bottom: ${spacing[8]};
+  grid-area: 1 / 2 / 3 / 3;
+
+  @media (min-width: ${IS_2_COL_BREAKPOINT}px) {
+    position: relative;
+    top: -48px;
+  }
+`;
+
+const RightRailSticky = styled.div`
+  position: sticky;
+  top: ${IN_PAGE_TOC_TOP_OFFSET}px;
+`;
+
+const RightRailRoot = styled(ScrollArea.Root)`
+  position: relative;
+  width: 240px;
+  margin: 0;
+  padding-bottom: 0;
+  padding-right: 20px;
+  margin-right: 20px;
+  height: calc(100vh - ${IN_PAGE_TOC_TOP_OFFSET}px);
+`;
+
+const RightRailViewport = styled(ScrollArea.Viewport)`
+  width: 100%;
+  height: 100%;
+  padding-top: 48px;
+`;
+
+const RightRailScrollbar = styled(ScrollArea.Scrollbar)`
+  display: flex;
+  width: 5px;
+  /* ensures no selection */
+  user-select: none;
+  /* disable browser handling of all panning and zooming gestures on touch devices */
+  touch-action: none;
+  padding-top: 48px;
+  padding-bottom: 24px;
+`;
+
+const RightRailThumb = styled(ScrollArea.Thumb)`
+  flex: 1;
+  width: 5px;
+  background: ${color.slate300};
+  border-radius: 20px;
+  position: relative;
+  transition: background 0.2s ease-in-out;
+
+  &:hover {
+    background: ${color.slate500};
+  }
+`;
+
+const Content = styled.div`
+  grid-area: 2 / 1 / 3 / 2;
+  min-width: 0;
+`;
 
 const MDWrapper = styled.main`
   ${mdFormatting}
   flex: 1;
 `;
 
+const Title = styled.h1`
+  font-size: ${typography.size.l1}px;
+  font-weight: ${typography.weight.bold};
+
+  line-height: 36px;
+  margin-bottom: 1.5rem;
+
+  & + * {
+    margin-top: 0 !important;
+  }
+`;
+
 const NextSubheading = styled(Subheading)`
-  color: ${color.mediumdark};
+  color: ${dsColor.mediumdark};
   font-size: ${typography.size.s2}px;
   display: block;
   margin-bottom: 1rem;
@@ -49,7 +157,7 @@ const GithubLinkItem = styled(Link)`
 
 const UnsupportedBanner = styled.div`
   margin: 26px 0;
-  border-radius: ${spacing.borderRadius.small}px;
+  border-radius: ${dsSpacing.borderRadius.small}px;
   background-color: #fff5cf;
   padding: 20px;
 `;
@@ -99,8 +207,15 @@ function DocsScreen({ data, pageContext, location }) {
     currentPage: {
       body,
       frontmatter: { title },
+      tableOfContents,
     },
   } = data;
+  const pageTocItems = tableOfContents?.items || [];
+
+  const hasHeadings =
+    pageTocItems.flatMap((item) => (item.items ? [item, ...item.items] : item)).length >
+    MIN_HEADINGS_COUNT_FOR_TOC;
+
   const {
     allRenderers,
     coreRenderers,
@@ -116,6 +231,8 @@ function DocsScreen({ data, pageContext, location }) {
     codeLanguage: [codeLanguage],
     renderer: [renderer],
   } = useDocsContext();
+
+  const [is2Col] = useMediaQuery(`(min-width: ${IS_2_COL_BREAKPOINT}px)`);
 
   const CodeSnippetsWithState = useMemo(() => {
     return (props) => (
@@ -199,80 +316,103 @@ function DocsScreen({ data, pageContext, location }) {
   return (
     <>
       <SocialGraph url={`${homepageUrl}${fullPath}/`} title={title} desc={description} />
-
-      <MDWrapper>
-        <Title>{isInstallPage ? `${title} for ${stylizeRenderer(renderer)}` : title}</Title>
-        <RendererSelector coreRenderers={coreRenderers} communityRenderers={communityRenderers} />
-        {unsupported && (
-          <UnsupportedBanner>
-            This feature is not supported in {stylizeRenderer(renderer)} yet. Help the open source
-            community by contributing a PR.
-            {featureSupportItem && (
-              <>
-                {' '}
-                <Link LinkWrapper={GatsbyLinkWrapper} href={featureSupportItem.path} withArrow>
-                  View feature coverage by renderer
-                </Link>
-              </>
+      <Root hasRightRail={hasHeadings}>
+        <Header>
+          <Title>{isInstallPage ? `${title} for ${stylizeRenderer(renderer)}` : title}</Title>
+          <RendererSelector coreRenderers={coreRenderers} communityRenderers={communityRenderers} />
+          {unsupported && (
+            <UnsupportedBanner>
+              This feature is not supported in {stylizeRenderer(renderer)} yet. Help the open source
+              community by contributing a PR.
+              {featureSupportItem && (
+                <>
+                  {' '}
+                  <Link LinkWrapper={GatsbyLinkWrapper} href={featureSupportItem.path} withArrow>
+                    View feature coverage by renderer
+                  </Link>
+                </>
+              )}
+            </UnsupportedBanner>
+          )}
+        </Header>
+        {hasHeadings && (
+          <RightRail>
+            {is2Col ? (
+              <RightRailSticky>
+                <RightRailRoot>
+                  <RightRailViewport>
+                    <InPageTOC items={pageTocItems} />
+                  </RightRailViewport>
+                  <RightRailScrollbar orientation="vertical">
+                    <RightRailThumb />
+                  </RightRailScrollbar>
+                </RightRailRoot>
+              </RightRailSticky>
+            ) : (
+              <InPageTOC collapsed items={pageTocItems} />
             )}
-          </UnsupportedBanner>
+          </RightRail>
         )}
-        <MDXProvider
-          components={{
-            pre: Pre,
-            CodeSnippets: CodeSnippetsWithState,
-            FeatureSnippets: FeatureSnippetsWithState,
-            RendererSupportTable: RendererSupportTableWithState,
-            If: IfWithState,
-            // Maintained for older docs version content
-            IfRenderer: IfWithState,
-            YouTubeCallout,
-            a: LinksWithPrefix,
-            Callout,
-          }}
-        >
-          <MDXRenderer>{body}</MDXRenderer>
-        </MDXProvider>
-      </MDWrapper>
+        <Content>
+          <MDWrapper>
+            <MDXProvider
+              components={{
+                pre: Pre,
+                CodeSnippets: CodeSnippetsWithState,
+                FeatureSnippets: FeatureSnippetsWithState,
+                RendererSupportTable: RendererSupportTableWithState,
+                If: IfWithState,
+                // Maintained for older docs version content
+                IfRenderer: IfWithState,
+                YouTubeCallout,
+                a: LinksWithPrefix,
+                Callout,
+              }}
+            >
+              <MDXRenderer>{body}</MDXRenderer>
+            </MDXProvider>
+          </MDWrapper>
 
-      {nextTocItem && (
-        <NextNavigation>
-          <NextSubheading>Next</NextSubheading>
-          <ShadowBoxCTA
-            action={
-              <Button
-                appearance="secondary"
-                href={buildPathWithVersion(nextTocItem.path)}
-                ButtonWrapper={GatsbyLinkWrapper}
-              >
-                Continue
-              </Button>
-            }
-            headingText={nextTocItem.title}
-            messageText={nextTocItem.description}
-          />
-        </NextNavigation>
-      )}
+          {nextTocItem && (
+            <NextNavigation>
+              <NextSubheading>Next</NextSubheading>
+              <ShadowBoxCTA
+                action={
+                  <Button
+                    appearance="secondary"
+                    href={buildPathWithVersion(nextTocItem.path)}
+                    ButtonWrapper={GatsbyLinkWrapper}
+                  >
+                    Continue
+                  </Button>
+                }
+                headingText={nextTocItem.title}
+                messageText={nextTocItem.description}
+              />
+            </NextNavigation>
+          )}
 
-      <Contribute>
-        {tocItem && (
-          <Feedback
-            key={fullPath}
-            slug={slug}
-            version={versionString}
-            renderer={renderer}
-            codeLanguage={codeLanguage}
-          />
-        )}
-        {tocItem && tocItem.githubUrl && (
-          <GithubLinkItem tertiary href={tocItem.githubUrl} target="_blank" rel="noopener">
-            <span role="img" aria-label="write">
-              ✍️
-            </span>{' '}
-            Edit on GitHub – PRs welcome!
-          </GithubLinkItem>
-        )}
-      </Contribute>
+          <Contribute>
+            {tocItem && (
+              <Feedback
+                key={fullPath}
+                slug={slug}
+                version={versionString}
+                renderer={renderer}
+                codeLanguage={codeLanguage}
+              />
+            )}
+            {tocItem && tocItem.githubUrl && (
+              <GithubLinkItem tertiary href={tocItem.githubUrl} target="_blank" rel="noopener">
+                <span role="img" aria-label="write">
+                  ✍️
+                </span>{' '}
+                Edit on GitHub – PRs welcome!
+              </GithubLinkItem>
+            )}
+          </Contribute>
+        </Content>
+      </Root>
     </>
   );
 }
@@ -286,6 +426,7 @@ export const query = graphql`
       frontmatter {
         title
       }
+      tableOfContents
     }
   }
 `;

--- a/src/components/screens/DocsScreen/RendererSelector.tsx
+++ b/src/components/screens/DocsScreen/RendererSelector.tsx
@@ -10,7 +10,6 @@ import { useDocsContext } from './DocsContext';
 const Root = styled.div`
   display: flex;
   gap: ${spacing[2]};
-  margin-bottom: ${spacing[8]};
 `;
 
 const Pill = styled('button', {

--- a/src/components/screens/DocsScreen/YouTubeCallout.tsx
+++ b/src/components/screens/DocsScreen/YouTubeCallout.tsx
@@ -21,6 +21,10 @@ const Details = styled.details`
   overflow: hidden;
   cursor: pointer;
 
+  && {
+    margin-top: 0;
+  }
+
   // hover states
   transition: all 150ms ease-out;
   transform: translate3d(0, 0, 0);

--- a/src/components/screens/DocsScreen/YouTubeCallout.tsx
+++ b/src/components/screens/DocsScreen/YouTubeCallout.tsx
@@ -17,7 +17,6 @@ const { color, typography, spacing } = styles;
 // `.lty-playbtn` styles emulate YouTube's thumbnail play button
 const Details = styled.details`
   border-radius: ${spacing.borderRadius.small}px;
-  box-shadow: 0 2px 5px 0 ${color.border};
   border: 1px solid ${color.border};
   overflow: hidden;
   cursor: pointer;

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -220,6 +220,9 @@ export const mdFormatting = css`
     margin: 2em 0;
     overflow: auto;
   }
+  table tbody {
+    vertical-align: top;
+  }
   table tr {
     border-top: 1px solid ${color.mediumlight};
     background-color: white;
@@ -275,7 +278,6 @@ export const mdFormatting = css`
   code {
     font-size: 87.5%;
     color: ${color.darkest};
-    white-space: pre;
   }
 
   pre {
@@ -290,6 +292,7 @@ export const mdFormatting = css`
     code {
       padding: 0;
       line-height: 1.43; /* 14px/20px */
+      white-space: pre;
     }
   }
 

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -11,7 +11,7 @@ export const mdFormatting = css`
   font-size: ${typography.size.s3}px;
 
   *:target {
-    scroll-margin-top: 48px; /* height of SubNav + 8px gap */
+    scroll-margin-top: 120px; /* height of NavWrapper + 8px gap */
   }
 
   h1,


### PR DESCRIPTION
### What I did

- Fix non-fluid DocsLayout
- Fix scroll margin of headings and code snippets
- Ensure `code` in content doesn't overflow column
- Remove drop shadow on YouTubeCallout
- Add "On this page" TOC
    - Add InPageTOC component
    - Query `tableOfContents` in DocsScreen
    - Add right rail to DocsScreen when wide enough to accommodate it

#### Wide viewports

![](https://github.com/storybookjs/frontpage/assets/486540/d1a40eb3-d6cf-426b-8354-d593fc21bd03)

> [!NOTE]
> Currently, this has to be _quite_ wide (1548px) for the main content to be wide enough to be legible. (The screenshot was taken at 1800px wide.) We need to discuss the overall page layout to improve this. [See related code comment.](https://github.com/storybookjs/frontpage/pull/628/files#diff-56237f547a4dc2c2c48b375dea50d79c8b7e20556b67152c6e7158c2b97c8567R34-R46).

### How to test

> [!NOTE]
> The broken sidebar links are a [known, unrelated issue](https://github.com/storybookjs/frontpage/pull/626).

1. Open the deploy preview
1. Navigate to a page with lots of headings, like the [`argTypes` API reference](https://deploy-preview-628--storybook-frontpage.netlify.app/docs/api/arg-types)
1. Confirm the "On this page" feature renders correctly
    1. At viewports > 1548px, it should be expanded, in the right rail
        1. Also confirm that the overall page layout looks correct, with no overflowing content
        1. Click one of the links
            1. Confirm that you are scrolled to the correct heading _and_ that it appears visibly, just under the sticky header
        1. Find a page with lots of headings ([`argTypes` API reference](https://deploy-preview-628--storybook-frontpage.netlify.app/docs/api/arg-types) is a good one)
            1. Shrink your browser's viewport _vertically_ until the full "On this page" section can't fit
                1. Confirm that the scrolling works as expected
    1. At viewports <= 1548px, it should not render
1. Navigate to a page with less than 4 headings, like the [Install page](https://deploy-preview-628--storybook-frontpage.netlify.app/docs/get-started/install)
    1. Confirm that the "On this page" feature is _not_ rendered