### PR TITLE
Docs design refresh fixes

### DIFF
--- a/src/components/layout/DocsLayout.tsx
+++ b/src/components/layout/DocsLayout.tsx
@@ -13,7 +13,6 @@ import {
   SCROLL_THUMB_WIDTH,
 } from '../../constants/style';
 import buildPathWithVersion from '../../util/build-path-with-version';
-import GatsbyLinkWrapper from '../basics/GatsbyLinkWrapper';
 import useSiteMetadata from '../lib/useSiteMetadata';
 import { DocsContextProvider } from '../screens/DocsScreen/DocsContext';
 import { VersionCTA } from '../screens/DocsScreen/VersionCTA';
@@ -203,14 +202,6 @@ const DocsLayout: FC<DocsLayoutProps> = ({ children, isLatest: isLatestProp, pag
 
   const tocSectionTitles = getTocSectionTitles(docsToc, slug.split('/docs/')[1]);
 
-  const addLinkWrappers = (items) =>
-    items.map((item) => ({
-      ...item,
-      ...(item.type.match(/link/) && { LinkWrapper: GatsbyLinkWrapper }),
-      ...(item.children && { children: addLinkWrappers(item.children) }),
-    }));
-  const docsTocWithLinkWrappers = addLinkWrappers(docsToc);
-
   return (
     <>
       <Helmet>
@@ -231,15 +222,7 @@ const DocsLayout: FC<DocsLayoutProps> = ({ children, isLatest: isLatestProp, pag
           content={GLOBAL_SEARCH_IMPORTANCE.DOCS}
         />
       </Helmet>
-      <PureDocsLayout
-        sidebar={
-          <Sidebar
-            docsTocWithLinkWrappers={docsTocWithLinkWrappers}
-            versions={versions}
-            slug={slug}
-          />
-        }
-      >
+      <PureDocsLayout sidebar={<Sidebar docsToc={docsToc} versions={versions} slug={slug} />}>
         {tocSectionTitles && (
           <span hidden id="toc-section-titles">
             {`Docs » ${tocSectionTitles}`}

--- a/src/components/layout/DocsLayout.tsx
+++ b/src/components/layout/DocsLayout.tsx
@@ -2,10 +2,16 @@ import React, { FC } from 'react';
 import { styled } from '@storybook/theming';
 import { global } from '@storybook/design-system';
 import Helmet from 'react-helmet';
-import { Container, color, minMd, minSm } from '@chromaui/tetra';
+import { Container, color, minMd, minSm, spacing } from '@chromaui/tetra';
 import * as ScrollArea from '@radix-ui/react-scroll-area';
 
 import { GLOBAL_SEARCH_IMPORTANCE, GLOBAL_SEARCH_META_KEYS } from '../../constants/global-search';
+import {
+  HEADER_HEIGHT,
+  HEADER_HEIGHT_WITH_EYEBROW,
+  SCROLL_CHANNEL_WIDTH,
+  SCROLL_THUMB_WIDTH,
+} from '../../constants/style';
 import buildPathWithVersion from '../../util/build-path-with-version';
 import GatsbyLinkWrapper from '../basics/GatsbyLinkWrapper';
 import useSiteMetadata from '../lib/useSiteMetadata';
@@ -14,6 +20,15 @@ import { VersionCTA } from '../screens/DocsScreen/VersionCTA';
 import { Sidebar } from './sidebar/Sidebar';
 
 const { GlobalStyle } = global;
+
+export const GUTTER = spacing[8];
+const OPTICAL_ALIGNMENT_WITH_LOGO = '7px';
+const FOCUS_OUTLINE_WIDTH = '2px';
+export const DOCS_TOP_PADDING = '24px';
+export const DOCS_TOP_PADDING_WIDE = '48px';
+export const DOCS_BOTTOM_PADDING = '24px';
+export const DOCS_BOTTOM_PADDING_WIDE = '48px';
+export const SIDEBAR_WIDTH = '240px';
 
 const BubblesBackground = styled.img`
   display: block;
@@ -24,14 +39,15 @@ const BubblesBackground = styled.img`
 `;
 
 const Wrapper = styled.div`
-  padding-top: 72px;
+  padding-top: ${HEADER_HEIGHT};
 
   @media (min-width: 440px) {
-    padding-top: 112px;
+    padding-top: ${HEADER_HEIGHT_WITH_EYEBROW};
   }
 
   ${minSm} {
     display: flex;
+    gap: calc(${GUTTER} - ${SCROLL_CHANNEL_WIDTH} + ${OPTICAL_ALIGNMENT_WITH_LOGO});
   }
 `;
 
@@ -41,44 +57,41 @@ const SidebarContainer = styled.div`
   ${minMd} {
     display: block;
     position: sticky;
-    top: 112px;
+    top: ${HEADER_HEIGHT_WITH_EYEBROW};
     align-self: flex-start;
   }
 `;
 
 const SidebarRoot = styled(ScrollArea.Root)`
   position: relative;
-
-  ${minMd} {
-    width: 260px;
-    margin: 0;
-    padding-bottom: 0;
-    padding-right: 20px;
-    margin-right: 20px;
-    height: calc(100vh - 112px);
-  }
+  left: calc(${OPTICAL_ALIGNMENT_WITH_LOGO} - ${FOCUS_OUTLINE_WIDTH});
+  width: ${SIDEBAR_WIDTH};
+  height: calc(100vh - ${HEADER_HEIGHT_WITH_EYEBROW});
 `;
 
 const SidebarViewport = styled(ScrollArea.Viewport)`
   width: 100%;
   height: 100%;
-  padding-top: 48px;
+  padding-top: ${DOCS_TOP_PADDING_WIDE};
+  padding-bottom: ${DOCS_BOTTOM_PADDING_WIDE};
+  padding-right: ${SCROLL_CHANNEL_WIDTH};
+  padding-left: ${FOCUS_OUTLINE_WIDTH};
 `;
 
 const ScrollAreaScrollbar = styled(ScrollArea.Scrollbar)`
   display: flex;
-  width: 5px;
+  width: ${SCROLL_THUMB_WIDTH};
   /* ensures no selection */
   user-select: none;
   /* disable browser handling of all panning and zooming gestures on touch devices */
   touch-action: none;
-  padding-top: 48px;
-  padding-bottom: 24px;
+  padding-top: ${DOCS_TOP_PADDING_WIDE};
+  padding-bottom: ${DOCS_BOTTOM_PADDING_WIDE};
 `;
 
 const ScrollAreaThumb = styled(ScrollArea.Thumb)`
   flex: 1;
-  width: 5px;
+  width: ${SCROLL_THUMB_WIDTH};
   background: ${color.slate300};
   border-radius: 20px;
   position: relative;
@@ -92,12 +105,12 @@ const ScrollAreaThumb = styled(ScrollArea.Thumb)`
 const Content = styled.div`
   flex: 1;
   min-width: 0;
-  padding-top: 24px;
-  padding-bottom: 24px;
+  padding-top: ${DOCS_TOP_PADDING};
+  padding-bottom: ${DOCS_BOTTOM_PADDING};
 
   ${minMd} {
-    padding-top: 48px;
-    padding-bottom: 48px;
+    padding-top: ${DOCS_TOP_PADDING_WIDE};
+    padding-bottom: ${DOCS_BOTTOM_PADDING_WIDE};
   }
 `;
 

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -101,7 +101,7 @@ const Line = styled.li`
 `;
 
 const AccordionRoot = styled.ul`
-  margin: 24px 0;
+  margin: 24px 0 0;
   padding: 0;
 `;
 

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -1,11 +1,12 @@
-import React, { FC, Fragment, ReactNode } from 'react';
+import React, { FC, Fragment } from 'react';
+import { Link } from 'gatsby';
 import { color, fontWeight, typography } from '@chromaui/tetra';
 import { keyframes, styled } from '@storybook/theming';
 import * as Accordion from '@radix-ui/react-accordion';
 import { ChevronSmallRightIcon } from '@storybook/icons';
-import { Link } from 'gatsby';
-import { VersionSelector } from './VersionSelector';
+
 import useSiteMetadata from '../../lib/useSiteMetadata';
+import { VersionSelector } from './VersionSelector';
 
 type SidebarElementProps = {
   type?: 'menu' | 'link' | 'heading';
@@ -14,12 +15,11 @@ type SidebarElementProps = {
   path?: string;
   githubUrl?: string;
   description?: string;
-  LinkWrapper?: ReactNode;
   children?: SidebarElementProps[];
 };
 
 interface SidebarProps {
-  docsTocWithLinkWrappers: SidebarElementProps[];
+  docsToc: SidebarElementProps[];
   versions: any;
   slug: string;
 }
@@ -187,11 +187,7 @@ const NavAccordionContent = styled(Accordion.Content)`
   }
 `;
 
-export const Sidebar: FC<SidebarProps> = ({
-  docsTocWithLinkWrappers,
-  versions: versionsProp,
-  slug,
-}) => {
+export const Sidebar: FC<SidebarProps> = ({ docsToc, versions: versionsProp, slug }) => {
   const { isLatest, version, versionString } = useSiteMetadata();
 
   const versions = versionsProp || {
@@ -239,11 +235,11 @@ export const Sidebar: FC<SidebarProps> = ({
       <Accordion.Root type="multiple" asChild>
         <AccordionRoot>
           {/* eslint-disable react/no-array-index-key */}
-          {docsTocWithLinkWrappers.map((lvl1, lvl1Index) => (
+          {docsToc.map((lvl1, lvl1Index) => (
             <Fragment key={lvl1Index}>
               <NavItem level={1}>
                 {['link', 'heading'].includes(lvl1.type) ? (
-                  <a href={lvl1.pathSegment}>{lvl1.title}</a>
+                  <Link to={lvl1.path}>{lvl1.title}</Link>
                 ) : (
                   lvl1.title
                 )}
@@ -254,7 +250,7 @@ export const Sidebar: FC<SidebarProps> = ({
                   <Fragment key={lvl2Index}>
                     {!lvl2.children && (
                       <NavItem level={2}>
-                        <a href={`${lvl1.pathSegment}/${lvl2.pathSegment}`}>{lvl2.title}</a>
+                        <Link to={lvl2.path}>{lvl2.title}</Link>
                       </NavItem>
                     )}
                     {lvl2.children && lvl2.children.length > 0 && (
@@ -268,7 +264,7 @@ export const Sidebar: FC<SidebarProps> = ({
                         <NavAccordionContent>
                           {lvl2.children.map((lvl3, lvl3Index) => (
                             <NavItem key={lvl3Index} level={3}>
-                              <a href={`${lvl1.pathSegment}/${lvl3.pathSegment}`}>{lvl3.title}</a>
+                              <Link to={lvl3.path}>{lvl3.title}</Link>
                             </NavItem>
                           ))}
                         </NavAccordionContent>

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -7,24 +7,30 @@ import { color, spacing } from '@chromaui/tetra';
 import { Button, Link, ShadowBoxCTA, Subheading, styles } from '@storybook/design-system';
 import * as ScrollArea from '@radix-ui/react-scroll-area';
 
-import { CodeSnippets } from './CodeSnippets';
-import { rendererSupportsFeature, RendererSupportTable } from './RendererSupportTable';
+import {
+  HEADER_HEIGHT_WITH_EYEBROW,
+  SCROLL_CHANNEL_WIDTH,
+  SCROLL_THUMB_WIDTH,
+} from '../../../constants/style';
+import { useMediaQuery } from '../../lib/useMediaQuery';
+import useSiteMetadata from '../../lib/useSiteMetadata';
+import { mdFormatting } from '../../../styles/formatting';
+import stylizeRenderer from '../../../util/stylize-renderer';
+import buildPathWithVersion from '../../../util/build-path-with-version';
+import relativeToRootLinks from '../../../util/relative-to-root-links';
 import { SocialGraph } from '../../basics';
 import { Callout } from '../../basics/Callout';
 import { InPageTOC } from '../../basics/InPageTOC';
 import { Pre } from '../../basics/Pre';
 import GatsbyLinkWrapper from '../../basics/GatsbyLinkWrapper';
-import { useMediaQuery } from '../../lib/useMediaQuery';
-import useSiteMetadata from '../../lib/useSiteMetadata';
-import { mdFormatting } from '../../../styles/formatting';
-import buildPathWithVersion from '../../../util/build-path-with-version';
-import relativeToRootLinks from '../../../util/relative-to-root-links';
-import stylizeRenderer from '../../../util/stylize-renderer';
+import { DOCS_BOTTOM_PADDING_WIDE, DOCS_TOP_PADDING_WIDE, GUTTER } from '../../layout/DocsLayout';
+import { CodeSnippets } from './CodeSnippets';
 import { useDocsContext } from './DocsContext';
 import { FeatureSnippets } from './FeatureSnippets';
 import { Feedback } from './Feedback';
 import { If } from './If';
 import { RendererSelector } from './RendererSelector';
+import { rendererSupportsFeature, RendererSupportTable } from './RendererSupportTable';
 import { YouTubeCallout } from './YouTubeCallout';
 
 const { color: dsColor, spacing: dsSpacing, typography } = styles;
@@ -44,12 +50,9 @@ const MIN_HEADINGS_COUNT_FOR_TOC = 3;
  *   b. Change the page layout for all SB properties, resulting in longer line lengths or necessary
  *      layout adjustments in some places
  */
-export const IS_2_COL_BREAKPOINT = 1548;
+export const IS_2_COL_BREAKPOINT = 1510;
 
 const RIGHT_RAIL_WIDTH = '220px';
-
-// Magic number to account for PageLayout header height
-const RIGHT_RAIL_TOP_OFFSET = '112px';
 
 const Root = styled('div', {
   shouldForwardProp: (prop) => prop !== 'hasRightRail',
@@ -59,7 +62,7 @@ const Root = styled('div', {
     css`
       display: flex;
       flex-direction: row-reverse;
-      gap: ${spacing[8]};
+      gap: ${GUTTER};
     `}
 `;
 
@@ -69,44 +72,43 @@ const Header = styled.div`
 
 const RightRail = styled.div`
   flex: 0 0 ${RIGHT_RAIL_WIDTH};
-  margin-bottom: ${spacing[8]};
   position: relative;
-  top: -48px;
+  top: -${DOCS_TOP_PADDING_WIDE};
 `;
 
 const RightRailSticky = styled.div`
   position: sticky;
-  top: ${RIGHT_RAIL_TOP_OFFSET};
+  top: ${HEADER_HEIGHT_WITH_EYEBROW};
 `;
 
 const RightRailRoot = styled(ScrollArea.Root)`
   position: relative;
   width: ${RIGHT_RAIL_WIDTH};
-  margin: 0;
-  padding-bottom: 0;
-  height: calc(100vh - ${RIGHT_RAIL_TOP_OFFSET});
+  height: calc(100vh - ${HEADER_HEIGHT_WITH_EYEBROW});
 `;
 
 const RightRailViewport = styled(ScrollArea.Viewport)`
   width: 100%;
   height: 100%;
-  padding-top: 48px;
+  padding-top: ${DOCS_TOP_PADDING_WIDE};
+  padding-bottom: ${DOCS_BOTTOM_PADDING_WIDE};
+  padding-right: ${SCROLL_CHANNEL_WIDTH};
 `;
 
 const RightRailScrollbar = styled(ScrollArea.Scrollbar)`
   display: flex;
-  width: 5px;
+  width: ${SCROLL_THUMB_WIDTH};
   /* ensures no selection */
   user-select: none;
   /* disable browser handling of all panning and zooming gestures on touch devices */
   touch-action: none;
-  padding-top: 48px;
-  padding-bottom: 24px;
+  padding-top: ${DOCS_TOP_PADDING_WIDE};
+  padding-bottom: ${DOCS_BOTTOM_PADDING_WIDE};
 `;
 
 const RightRailThumb = styled(ScrollArea.Thumb)`
   flex: 1;
-  width: 5px;
+  width: ${SCROLL_THUMB_WIDTH};
   background: ${color.slate300};
   border-radius: 20px;
   position: relative;

--- a/src/components/screens/DocsScreen/RendererSelector.tsx
+++ b/src/components/screens/DocsScreen/RendererSelector.tsx
@@ -99,8 +99,14 @@ type RendererSelectorProps = {
 
 export const RendererSelector = ({ coreRenderers, communityRenderers }: RendererSelectorProps) => {
   const {
-    renderer: [renderer, setRenderer],
+    renderer: [rendererFromContext, setRenderer],
   } = useDocsContext();
+
+  const [isClient, setIsClient] = React.useState(false);
+  React.useEffect(() => {
+    setIsClient(true);
+  }, []);
+  const renderer = isClient ? rendererFromContext : 'LOCAL_STORAGE_NOT_AVAILABLE';
 
   const pillItems = coreRenderers.slice();
   const menuItems = communityRenderers.slice();

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -1,0 +1,6 @@
+export const HEADER_HEIGHT = '72px';
+
+export const HEADER_HEIGHT_WITH_EYEBROW = '112px';
+
+export const SCROLL_THUMB_WIDTH = '5px';
+export const SCROLL_CHANNEL_WIDTH = '10px';

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -161,7 +161,7 @@ export const mdFormatting = css`
     display: flex;
     transition: transform 250ms ease-out;
     transform: translate3d(-100%, -50%, 0);
-    padding-right: 10px;
+    padding-right: 5px;
 
     &:hover {
       transform: translate3d(-100%, calc(-50% - 1px), 0);

--- a/src/util/add-state-to-toc.js
+++ b/src/util/add-state-to-toc.js
@@ -6,7 +6,7 @@ module.exports = function addStateToToc(items, pathPrefix = '/docs') {
 
     return {
       ...item,
-      ...(item.type.match(/link/) && {
+      ...(item.type.match(/link|heading/) && {
         path: itemPath,
         githubUrl: `${githubDocsBaseUrl}${itemPath}.md`,
       }),


### PR DESCRIPTION
### What I did

- Fix flash of default renderer in RendererSelector
- Style fixes
    - Optically align sidebar icons with header logo
    - Ensure focus outline of sidebar links don't overflow scroll viewport
        - While maintaining correct gutter width between sidebar & content
    - Decreased sidebar width to minimum necessary
    - Narrowed the scroll channel width to minimum necessary
    - Bottom padding of sidebar and right rail matches content
    - Decreased breakpoint width at which "On this page" appears
        - Still maintains the 600px minimum width of main content
    - Extracted a bunch of styling constants to communicate intent and express relationships
- Fix sidebar links
    - Use correct `path`
    - Use Gatsby Link instead of `a`
    - Ensure future `heading` type TOC items are processed correctly
    - Simplify logic

This screenshot illustrates a number of fixes:

<img width="346" alt="" src="https://github.com/storybookjs/frontpage/assets/486540/c64f91df-7d57-4fd7-986b-d10ec9d7077b">

1. Optical alignment of logo and sidebar icons (and the rest of the sidebar with them)
1. Un-clipped focus outline on sidebar item
1. Non-overlapping anchor link icon and sidebar scrollbar
1. Reduced scrollbar channel

### How to test

1. Open the deploy preview
1. Focus a sidebar link
    1. Confirm that the focus outline is no longer clipped
1. Click a sidebar link
    1. Confirm you are navigated to the correct page
1. (at default zoom level) Confirm sidebar items do not wrap
1. Hover over a heading in the content
    1. Confirm that the anchor link icon does not overlap the sidebar's scrollbar
1. Confirm that the "On this page" now appears when viewport is >= 1510px
1. Confirm sidebar and "On this page" scroll bars have adequate room
1. Scroll all the way to the bottom of a page and also scroll the sidebar all the way to the bottom
    1. Confirm that the bottom edges of the content are aligned