### PR TITLE
Various TOC improvements

### DIFF
--- a/src/components/layout/DocsLayout/Sidebar.tsx
+++ b/src/components/layout/DocsLayout/Sidebar.tsx
@@ -13,6 +13,7 @@ type SidebarElementProps = {
   title?: string;
   pathSegment?: string;
   path?: string;
+  redirectPath?: string;
   githubUrl?: string;
   description?: string;
   children?: SidebarElementProps[];
@@ -267,7 +268,7 @@ export const Sidebar: FC<SidebarProps> = ({ docsToc, versions: versionsProp, slu
           {/* eslint-disable react/no-array-index-key */}
           {docsToc.map((lvl1, lvl1Index) => (
             <Fragment key={lvl1Index}>
-              <NavItem level={1} isCurrent={lvl1.path === slug}>
+              <NavItem level={1} isCurrent={lvl1.path === slug && !lvl1.redirectPath}>
                 {['link', 'heading'].includes(lvl1.type) ? (
                   <Link to={lvl1.path}>{lvl1.title}</Link>
                 ) : (

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -211,7 +211,7 @@ function DocsScreen({ data, pageContext, location }) {
   const {
     currentPage: {
       body,
-      frontmatter: { title },
+      frontmatter: { hideRendererSelector, title },
       tableOfContents,
     },
   } = data;
@@ -258,8 +258,9 @@ function DocsScreen({ data, pageContext, location }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [renderer]);
   const LinksWithPrefix = useMemo(() => {
+    const isIndexPage = tocItem.type === 'heading' && !tocItem.redirectPath;
     return ({ children, href, ...props }) => {
-      const url = relativeToRootLinks(href, location.pathname);
+      const url = relativeToRootLinks(href, location.pathname, isIndexPage);
       return (
         <a href={url} {...props}>
           {children}
@@ -339,10 +340,12 @@ function DocsScreen({ data, pageContext, location }) {
         <Content>
           <Header>
             <Title>{isInstallPage ? `${title} for ${stylizeRenderer(renderer)}` : title}</Title>
-            <RendererSelector
-              coreRenderers={coreRenderers}
-              communityRenderers={communityRenderers}
-            />
+            {!hideRendererSelector && (
+              <RendererSelector
+                coreRenderers={coreRenderers}
+                communityRenderers={communityRenderers}
+              />
+            )}
             {unsupported && (
               <UnsupportedBanner>
                 This feature is not supported in {stylizeRenderer(renderer)} yet. Help the open
@@ -430,6 +433,7 @@ export const query = graphql`
       body
       frontmatter {
         title
+        hideRendererSelector
       }
       tableOfContents
     }

--- a/src/content/releases/7.5.md
+++ b/src/content/releases/7.5.md
@@ -1,5 +1,7 @@
 ---
 title: 'Storybook 7.5 - October 2023'
+# TODO: Remove after https://github.com/storybookjs/storybook/pull/24830 is merged
+hideRendererSelector: true
 ---
 
 - ⚡️ Vite 5 and Lit 3.0 support

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -1,11 +1,12 @@
 import { styles } from '@storybook/design-system';
 import { css } from '@storybook/theming';
+import { color, fontWeight } from '@chromaui/tetra';
 import { darken, rgba } from 'polished';
 
 import { CODE_SNIPPET_CLASSNAME } from '../constants/code-snippets';
 import { HEADER_HEIGHT_WITH_EYEBROW } from '../constants/style';
 
-const { color, typography } = styles;
+const { color: dsColor, typography } = styles;
 
 export const mdFormatting = css`
   line-height: 28px;
@@ -40,8 +41,8 @@ export const mdFormatting = css`
     &:target {
       background: linear-gradient(
         90deg,
-        ${rgba(color.secondary, 0.1)} 0%,
-        ${rgba(color.secondary, 0.0)} 70%
+        ${rgba(dsColor.secondary, 0.1)} 0%,
+        ${rgba(dsColor.secondary, 0.0)} 70%
       );
     }
   }
@@ -138,7 +139,7 @@ export const mdFormatting = css`
     &:hover,
     &:focus,
     &:hover:focus {
-      color: ${darken(0.2, color.secondary)};
+      color: ${darken(0.2, dsColor.secondary)};
     }
 
     &:hover {
@@ -168,12 +169,12 @@ export const mdFormatting = css`
       transform: translate3d(-100%, calc(-50% - 1px), 0);
 
       path {
-        fill: ${color.dark};
+        fill: ${dsColor.dark};
       }
     }
 
     path {
-      fill: ${color.mediumdark};
+      fill: ${dsColor.mediumdark};
       transition: fill 250ms ease-out;
     }
 
@@ -201,7 +202,7 @@ export const mdFormatting = css`
   .aside {
     font-size: 87.5%;
     line-height: 1.43;
-    color: ${color.dark};
+    color: ${dsColor.dark};
     background: #f8fafc;
     border-radius: ${styles.spacing.borderRadius.small}px;
     padding: 1em;
@@ -215,7 +216,6 @@ export const mdFormatting = css`
   /* Tables based on GH markdown format */
   table {
     font-size: ${typography.size.s2}px;
-    padding: 0;
     border-collapse: collapse;
     width: 100%;
     margin: 2em 0;
@@ -225,37 +225,15 @@ export const mdFormatting = css`
     vertical-align: top;
   }
   table tr {
-    border-top: 1px solid ${color.mediumlight};
-    background-color: white;
-    margin: 0;
-    padding: 0;
-  }
-  table tr:nth-child(2n) {
-    background-color: ${color.lighter};
+    border-bottom: 1px solid ${color.slate300};
   }
   table tr th {
-    font-weight: bold;
-    border: 1px solid ${color.medium};
-    border-radius: 3px 3px 0 0;
+    font-weight: ${fontWeight.semibold};
     text-align: left;
-    margin: 0;
-    padding: 0.5em 0.75em;
+    padding: 0.5em 0.75em 0.5em 0;
   }
   table tr td {
-    border: 1px solid #ddd;
-    text-align: left;
-    margin: 0;
-    padding: 0.5em 1em;
-  }
-
-  table tr th :first-child,
-  table tr td:first-child {
-    margin-top: 0;
-  }
-
-  table tr th :last-child,
-  table tr td:last-child {
-    margin-bottom: 0;
+    padding: 0.5em 0.75em 0.5em 0;
   }
 
   iframe {
@@ -278,7 +256,7 @@ export const mdFormatting = css`
 
   code {
     font-size: 87.5%;
-    color: ${color.darkest};
+    color: ${dsColor.darkest};
   }
 
   pre {
@@ -288,7 +266,7 @@ export const mdFormatting = css`
 
     padding: 1em;
     font-size: inherit;
-    color: ${color.darkest};
+    color: ${dsColor.darkest};
 
     code {
       padding: 0;
@@ -299,7 +277,7 @@ export const mdFormatting = css`
 
   blockquote {
     font-size: ${typography.size.m1}px;
-    color: ${color.mediumdark};
+    color: ${dsColor.mediumdark};
     line-height: 1.75;
     margin-top: 2rem;
     margin-bottom: 2.5rem;
@@ -322,8 +300,8 @@ export const mdFormatting = css`
     &:target {
       background: linear-gradient(
         90deg,
-        ${rgba(color.secondary, 0.1)} 0%,
-        ${rgba(color.secondary, 0.0)} 70%
+        ${rgba(dsColor.secondary, 0.1)} 0%,
+        ${rgba(dsColor.secondary, 0.0)} 70%
       );
     }
   }
@@ -331,14 +309,14 @@ export const mdFormatting = css`
   details > summary {
     display: list-item;
     cursor: pointer;
-    color: ${darken(0.2, color.secondary)};
+    color: ${darken(0.2, dsColor.secondary)};
   }
 
   details[open] {
     position: relative;
 
     &:before {
-      border-left: 1px solid ${color.border};
+      border-left: 1px solid ${dsColor.border};
       content: '';
       height: 100%;
       left: 4px;

--- a/src/util/add-state-to-toc.js
+++ b/src/util/add-state-to-toc.js
@@ -1,16 +1,22 @@
 const githubDocsBaseUrl = 'https://github.com/storybookjs/storybook/tree/next';
 
+function prefixPath(path, prefix) {
+  return path ? `${prefix}/${path}` : prefix;
+}
+
 module.exports = function addStateToToc(items, pathPrefix = '/docs') {
   return items.map((item) => {
-    const itemPath = item.pathSegment ? `${pathPrefix}/${item.pathSegment}` : pathPrefix;
+    const isIndexPage = item.type === 'heading' && !item.redirectPath;
+
+    const path = prefixPath(item.pathSegment, pathPrefix);
 
     return {
       ...item,
       ...(item.type.match(/link|heading/) && {
-        path: itemPath,
-        githubUrl: `${githubDocsBaseUrl}${itemPath}.md`,
+        path: item.redirectPath ? prefixPath(item.redirectPath, pathPrefix) : path,
+        githubUrl: `${githubDocsBaseUrl}${path}${isIndexPage ? '/index' : ''}.md`,
       }),
-      ...(item.children && { children: addStateToToc(item.children, itemPath) }),
+      ...(item.children && { children: addStateToToc(item.children, path) }),
     };
   });
 };

--- a/src/util/relative-to-root-links.js
+++ b/src/util/relative-to-root-links.js
@@ -14,7 +14,7 @@ function removeMdExtension(path) {
  * ../../app/ember/README.md remains untouched (these are converted to github links elsewhere)
  * /addons remains untouched
  */
-function relativeToRootLinks(href, path = '') {
+function relativeToRootLinks(href, path = '', isIndexPage) {
   const relativeUrlRegex = /^(?!\.\.\/\.\.\/)(\.\/)(.*)$/;
   const multiLevelRelativeUrlRegex = /^(?!\.\.\/\.\.\/)(\.\.\/)(.*)$/;
 
@@ -28,17 +28,25 @@ function relativeToRootLinks(href, path = '') {
     return removeMdExtension(url);
   }
 
-  if (relativeUrlRegex.test(href)) {
+  if (isIndexPage && relativeUrlRegex.test(url)) {
+    const slugParts = path.split('/').filter((p) => !!p);
+    const parentPart = slugParts.pop();
+
+    // ./some-path to `../parent/some-path`
+    url = url.replace(/^\.\//, `../${parentPart}/`);
+  }
+
+  if (relativeUrlRegex.test(url)) {
     // rewrite ./some-path style urls to /docs/version?/parent/some-path
     const slugParts = path.split('/').filter((p) => !!p);
-    slugParts.splice(-1, 1, href.replace(relativeUrlRegex, '$2'));
+    slugParts.splice(-1, 1, url.replace(relativeUrlRegex, '$2'));
     url = `/${slugParts.join('/')}`;
     return removeMdExtension(url);
   }
 
-  if (multiLevelRelativeUrlRegex.test(href)) {
+  if (multiLevelRelativeUrlRegex.test(url)) {
     // rewrite ../parent/some-path style urls to /docs/version?/parent/some-path
-    url = buildPathWithVersion(href.replace(multiLevelRelativeUrlRegex, '/docs/$2'));
+    url = buildPathWithVersion(url.replace(multiLevelRelativeUrlRegex, '/docs/$2'));
     return removeMdExtension(url);
   }
 

--- a/src/util/relative-to-root-links.test.ts
+++ b/src/util/relative-to-root-links.test.ts
@@ -1,16 +1,18 @@
 import relativeToRootLinks from './relative-to-root-links';
 
 it('transforms sibling-level links', () => {
-  const rootUrl = relativeToRootLinks('./args.md', '/docs/writing-stories/introduction');
+  const rootUrl = relativeToRootLinks('./args.md', '/docs/writing-stories/decorators');
+  expect(rootUrl).toEqual('/docs/writing-stories/args');
+});
+
+it('transforms sibling-level links on index pages', () => {
+  const rootUrl = relativeToRootLinks('./args.md', '/docs/writing-stories', true);
   expect(rootUrl).toEqual('/docs/writing-stories/args');
 });
 
 it('transforms parent-level links', () => {
-  const rootUrl = relativeToRootLinks(
-    '../writing-docs/introduction.md',
-    '/docs/writing-stories/introduction'
-  );
-  expect(rootUrl).toEqual('/docs/writing-docs/introduction');
+  const rootUrl = relativeToRootLinks('../writing-docs/autodocs.md', '/docs/writing-stories/args');
+  expect(rootUrl).toEqual('/docs/writing-docs/autodocs');
 });
 
 it('transforms specific-version links', () => {
@@ -22,20 +24,14 @@ it('transforms specific-version links', () => {
 });
 
 it('does not transform non-versioned upper-level links', () => {
-  const rootUrl = relativeToRootLinks(
-    '../../foo/bar/README.md',
-    '/docs/writing-stories/introduction'
-  );
+  const rootUrl = relativeToRootLinks('../../foo/bar/README.md', '/docs/writing-stories/args');
   expect(rootUrl).toEqual('../../foo/bar/README.md');
 
-  const rootUrl2 = relativeToRootLinks(
-    '../../../foo/bar/README.md',
-    '/docs/writing-stories/introduction'
-  );
+  const rootUrl2 = relativeToRootLinks('../../../foo/bar/README.md', '/docs/writing-stories/args');
   expect(rootUrl2).toEqual('../../../foo/bar/README.md');
 });
 
 it('does not transform non-relative links', () => {
-  const rootUrl = relativeToRootLinks('/foo', '/docs/writing-stories/introduction');
+  const rootUrl = relativeToRootLinks('/foo', '/docs/writing-stories/args');
   expect(rootUrl).toEqual('/foo');
 });


### PR DESCRIPTION
- Handle headings that redirect to another path
- Add support for `hideRendererSelector` in frontmatter
- Ensure `index.md` pages still work with "Edit on GitHub" links and `relative-to-root-links`
- Simplify markdown table styling