### PR TITLE
Updates for Storybook `7.6`

### DIFF
--- a/src/content/releases/7.6.md
+++ b/src/content/releases/7.6.md
@@ -1,0 +1,20 @@
+---
+title: 'Storybook 7.6 - November 2023'
+# TODO: Remove after https://github.com/storybookjs/storybook/pull/24830 is merged
+hideRendererSelector: true
+---
+
+- 💃🏼 Now supports Lit 3.0 and Vite 5
+- 👻 storiesOf and storyStoreV6 officially deprecated
+- 🔨 Fix Webpack5 build errors not being propagated
+- 🀄 Support rename font import for Next.js
+- ⬆️ Upgrade react-docgen to 6.0.x and improve argTypes
+- ✨ Many Angular improvements such as introducing argsToTemplate , new schema debugging options, support for standalone directives, etc.
+
+Lots of little fixes and improvements. Browse the [changelogs](https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md) for the full list of changes.
+
+---
+
+There are no breaking changes, but you can refer to our
+[Migration guide](https://storybook.js.org/migration-guides/7.0) to upgrade from
+pre-7.0 of Storybook.

--- a/src/util/redirects-raw.txt
+++ b/src/util/redirects-raw.txt
@@ -28,6 +28,7 @@
 /docs/addons/introduction                        /docs/addons                                                                   301
 /docs/addons/addon-catalog                       /docs/addons/integration-catalog                                               301
 /docs/configure/overview                         /docs/configure                                                                301
+/docs/configure/babel                            /docs/configure/compilers                                                      301
 /docs/configure/webpack                          /docs/builders/webpack                                                         301
 /docs/builders/overview                          /docs/builders                                                                 301
 /docs/api/addons                                 /docs/addons/introduction                                                      301

--- a/static/_redirects
+++ b/static/_redirects
@@ -59,7 +59,7 @@
 /docs/configurations/options-parameter/     /docs/configure/features-and-behavior/                                                              301
 /docs/configurations/default-config/        /docs/configure/overview/                                                                           301
 /docs/configurations/custom-webpack-config/ /docs/builders/webpack/                                                                             301
-/docs/configurations/custom-babel-config/   /docs/configure/babel/                                                                              301
+/docs/configurations/custom-babel-config/   /docs/configure/compilers/                                                                              301
 /docs/configurations/typescript-config/     /docs/configure/typescript/                                                                         301
 /docs/configurations/add-custom-head-tags/  /docs/configure/story-rendering#adding-to-head                                                      301
 /docs/configurations/add-custom-body/       /docs/configure/story-rendering#adding-to-body                                                      301


### PR DESCRIPTION
> [!WARNING]
> This should only be merged after Storybook `7.6` is released.

This will also almost certainly have merge conflicts with https://github.com/storybookjs/frontpage/pull/626, which is likely to be merged prior to this one. I (Kyle) will deal with that.