### PR TITLE
Snippet fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@storybook/react": "^6.5.9",
     "@storybook/testing-library": "^0.0.11",
     "@types/jest": "^27.0.0",
+    "@types/react": "^18",
     "babel-preset-gatsby": "^2.16.0",
     "chromatic": "^6.14.0",
     "concurrently": "^5.3.0",

--- a/src/components/basics/CodeSnippets/BaseCodeSnippet/BaseCodeSnippet.tsx
+++ b/src/components/basics/CodeSnippets/BaseCodeSnippet/BaseCodeSnippet.tsx
@@ -124,7 +124,7 @@ export const BaseCodeSnippet = ({
   const { isLoadingHighlighter, generateSnippetHTML } = useSyntaxHighlighter();
 
   return (
-    <CodeSnippetContainer withTabs={withTabs} {...rest}>
+    <CodeSnippetContainer id={id} withTabs={withTabs} {...rest}>
       {hideHeader ? null : (
         <CodeSnippetHeader>
           <CodeSnippetHeaderLeft>

--- a/src/components/basics/CodeSnippets/SyntaxHighlighterContext.tsx
+++ b/src/components/basics/CodeSnippets/SyntaxHighlighterContext.tsx
@@ -31,7 +31,7 @@ const SyntaxHighlighterContext = createContext<SyntaxHighlighterContextValue>({
   generateSnippetHTML: (code: string, lang: SupportedLanguages) => '',
 });
 
-export const SyntaxHighlighterContextProvider: React.FC = ({ children }) => {
+export const SyntaxHighlighterContextProvider = ({ children }) => {
   const [isLoadingHighlighter, setIsLoadingHighlighter] = useState(true);
   const [highlighterInstance, setHighlighterInstance] = useState<Highlighter | undefined>();
 

--- a/src/components/basics/CodeSnippets/utils/parse-snippet-content.utils.ts
+++ b/src/components/basics/CodeSnippets/utils/parse-snippet-content.utils.ts
@@ -27,6 +27,10 @@ const parseNameFromComment = (comment: string) => {
   if (name.includes('#')) {
     name = name.replace('#', '');
   }
+  // MDX comments
+  if (name.includes('{/*')) {
+    name = name.replace('{/*', '').replace('*/}', '');
+  }
   // JS and TS multi line comments, CSS comments
   if (name.includes('/*')) {
     name = name.replace('/*', '').replace('*/', '');
@@ -50,16 +54,20 @@ export const parseSnippetContent = (
   content: string,
   isTerminalSnippet?: boolean
 ): ParsedSnippet => {
+  const lines = content.split('\n');
+
   if (isTerminalSnippet) {
-    const command = trimSnippet(content.split('\n'));
+    const command = trimSnippet(lines);
 
     return ['Terminal', command];
   }
 
-  const [firstLine, ...rest] = content.split('\n');
-  const fileName = stringIsComment(firstLine) ? parseNameFromComment(firstLine) : '';
+  const [firstLine, ...rest] = lines;
+  // All snippets have an empty last line, so a one-line snippet will have a length of 2
+  const yoinkFileNameComment = stringIsComment(firstLine) && lines.length > 2;
+  const fileName = yoinkFileNameComment ? parseNameFromComment(firstLine) : '';
 
-  const code = trimSnippet([...(stringIsComment(firstLine) ? [] : [firstLine]), ...rest]);
+  const code = trimSnippet([...(yoinkFileNameComment ? [] : [firstLine]), ...rest]);
 
   return [fileName, code];
 };

--- a/src/components/basics/Pre.tsx
+++ b/src/components/basics/Pre.tsx
@@ -4,6 +4,8 @@ import { BaseCodeSnippet } from './CodeSnippets/BaseCodeSnippet';
 import { parseSnippetContent } from './CodeSnippets/utils/parse-snippet-content.utils';
 
 export const Pre = ({ children }) => {
+  const id = React.useId();
+
   const { className = '', children: code } = children.props;
   const syntax = className.replace(/language-/, '');
   const isTerminal = syntax === 'shell';
@@ -13,7 +15,7 @@ export const Pre = ({ children }) => {
   return (
     <BaseCodeSnippet
       hideHeader={hideHeader}
-      id="snippet-1"
+      id={`pre-${id}`}
       snippet={snippet}
       syntax={syntax}
       title={title}

--- a/src/components/screens/DocsScreen/CodeSnippets/CodeSnippets.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets/CodeSnippets.tsx
@@ -29,7 +29,7 @@ const CSF2_MESSAGE_VERSION_THRESHOLD = 7.6;
 export interface CodeSnippetProps {
   csf2Path?: string;
   currentCodeLanguage: string;
-  currentPackageManager?: string;
+  currentPackageManager: string;
   currentRenderer: string;
   paths: string[];
   usesCsf3?: boolean;

--- a/src/components/screens/DocsScreen/CodeSnippets/fetch-snippets.utils.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets/fetch-snippets.utils.tsx
@@ -117,11 +117,11 @@ export const fetchDocsSnippets = async (
             // TODO: consider logging this somewhere so the team can fix it
             return null;
           }
+        } else {
+          // If path doesn't exist, don't show the snippet
+          // TODO: consider logging this somewhere so the team can fix it
+          return null;
         }
-
-        // If path doesn't exist, don't show the snippet
-        // TODO: consider logging this somewhere so the team can fix it
-        return null;
       }
 
       const [title, content] = parseSnippetContent(

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -312,12 +312,15 @@ function DocsScreen({ data, pageContext, location }) {
   );
   React.useEffect(() => {
     if (numCodeSnippets > 0 && hash) {
+      document.querySelector('[data-active-target]')?.removeAttribute('data-active-target');
+
       // Wait for whichever happens first: all snippets on the page to render or 500ms
       waitForElementsToDisplay(
         '[id^=snippet]',
         numCodeSnippets,
         () => {
           const element = document.querySelector(hash);
+          element?.setAttribute('data-active-target', 'true');
           element?.scrollIntoView();
         },
         50,

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -12,7 +12,8 @@ export const mdFormatting = css`
   line-height: 28px;
   font-size: ${typography.size.s3}px;
 
-  *:target {
+  *:target,
+  [data-active-target] {
     scroll-margin-top: calc(${HEADER_HEIGHT_WITH_EYEBROW} + 8px);
   }
 
@@ -38,7 +39,8 @@ export const mdFormatting = css`
       transition: opacity 250ms ease-out;
     }
 
-    &:target {
+    &:target,
+    &[data-active-target] {
       background: linear-gradient(
         90deg,
         ${rgba(dsColor.secondary, 0.1)} 0%,

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -271,6 +271,7 @@ export const mdFormatting = css`
     color: ${dsColor.darkest};
 
     code {
+      font-size: 13px;
       padding: 0;
       line-height: 1.43; /* 14px/20px */
       white-space: pre;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6372,6 +6372,15 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/react@^18":
+  version "18.2.39"
+  resolved "https://registry.npmjs.org/@types/react/-/react-18.2.39.tgz#744bee99e053ad61fe74eb8b897f3ab5b19a7e25"
+  integrity sha512-Oiw+ppED6IremMInLV4HXGbfbG6GyziY3kqAwJYOR0PNbkYDmLWQA3a95EhdSmamsvbkJN96ZNN+YD+fGjzSBA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
@@ -6393,6 +6402,11 @@
   integrity sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==
   dependencies:
     "@types/node" "*"
+
+"@types/scheduler@*":
+  version "0.16.8"
+  resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
+  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.1.0":
   version "7.3.13"


### PR DESCRIPTION
- Add `@types/react`
- Apply `id` attribute to CodeSnippets and Pres
    - So that https://github.com/storybookjs/frontpage/pull/503 can do its thing
- Reduce font-size of code blocks
- Ensure not-found ts-4-9 snippets fall back to ts
- Parse MDX comments into snippet titles
- Fix type errors

### Before

<table>
  <tr>
    <td>
      <img width="688" alt="1-before" src="https://github.com/storybookjs/frontpage/assets/486540/0d78c00d-8b41-496c-bcbb-85dda2d4d000">
      Here, TS 4.9 was selected, causing the snippet to disappear entirely
    </td>
    <td>
      <img width="687" alt="2-before" src="https://github.com/storybookjs/frontpage/assets/486540/caeb1e81-9323-4771-8346-701997d1e0d0">
      Note the first empty snippet and the `{` & `}` wrapping the titles
    </td>
  </tr>
</table>

### After

<table>
  <tr>
    <td>
      <img width="688" alt="1-after" src="https://github.com/storybookjs/frontpage/assets/486540/89ceaf68-e7e6-4372-ab87-cdc6d884c8be">
      Note that TS 4.9 is selected and the snippet still renders the TS version
    </td>
    <td>
      <img width="690" alt="2-after" src="https://github.com/storybookjs/frontpage/assets/486540/0df225aa-c5de-4dd9-bee6-d38708c18b47">
      Note that the one-line snippet displays properly and the titles are correct
    </td>
  </tr>
</table>