### PR TITLE
Various fixes, inc. FrameworkSupportTable, broken images, and versioned generated redirects

### DIFF
--- a/site-metadata.js
+++ b/site-metadata.js
@@ -100,10 +100,10 @@ const siteMetadata = {
 
     // Official addons
     officialAddons: {
-      docs: '/docs/react/addons/introduction/',
-      install: '/docs/react/addons/install-addons/',
-      create: '/docs/react/addons/writing-addons/',
-      publish: '/docs/react/addons/integration-catalog/',
+      docs: '/docs/addons/',
+      install: '/docs/addons/install-addons/',
+      create: '/docs/addons/writing-addons/',
+      publish: '/docs/addons/integration-catalog/',
       controls: `${essentialsBase}/controls`,
       actions: `${essentialsBase}/actions`,
       viewport: `${essentialsBase}/viewport`,

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -384,6 +384,8 @@ function DocsScreen({ data, pageContext, location }) {
                   CodeSnippets: CodeSnippetsWithState,
                   FeatureSnippets: FeatureSnippetsWithState,
                   RendererSupportTable: RendererSupportTableWithState,
+                  // Maintained for older docs version content
+                  FrameworkSupportTable: RendererSupportTableWithState,
                   If: IfWithState,
                   // Maintained for older docs version content
                   IfRenderer: IfWithState,

--- a/src/components/screens/IndexScreen/Develop.js
+++ b/src/components/screens/IndexScreen/Develop.js
@@ -287,12 +287,7 @@ export function Develop({ docs, startOpen, ...props }) {
             heading="Supercharge your workflow with addons"
             description="Addons extend and customize your UI development workflow. There are hundreds of addons that help you build UI faster, document component libraries, and integrate with other tools."
             links={
-              <Link
-                containsIcon
-                withArrow
-                href={`${docs}react/addons/introduction`}
-                LinkWrapper={GatsbyLinkWrapper}
-              >
+              <Link containsIcon withArrow href={`${docs}addons`} LinkWrapper={GatsbyLinkWrapper}>
                 Learn about addons
               </Link>
             }

--- a/src/components/screens/IndexScreen/Document.js
+++ b/src/components/screens/IndexScreen/Document.js
@@ -45,7 +45,7 @@ const features = [
     description: 'Write Markdown and build custom docs.',
     link: {
       label: 'Learn about docs addon',
-      href: '/docs/react/writing-docs/introduction',
+      href: '/docs/writing-docs',
       LinkWrapper: GatsbyLinkWrapper,
     },
     media: 'videos/document/homepage-component-document-lg.mp4',

--- a/src/components/screens/IndexScreen/Test.js
+++ b/src/components/screens/IndexScreen/Test.js
@@ -33,7 +33,7 @@ const features = [
     description: 'Stories are tests you can debug in dev and QA.',
     link: {
       label: 'Learn about UI tests',
-      href: '/docs/react/writing-tests/introduction',
+      href: '/docs/writing-tests',
       LinkWrapper: GatsbyLinkWrapper,
     },
     media: 'videos/test/homepage-spot-testing-lg.mp4',

--- a/src/components/screens/IntegrationsCatalog/AddonsDetailScreen/AddonsDetailScreen.js
+++ b/src/components/screens/IntegrationsCatalog/AddonsDetailScreen/AddonsDetailScreen.js
@@ -231,7 +231,9 @@ export const AddonsDetailScreen = ({ path, location, pageContext }) => {
                   limit={6}
                   tags={orderedCompatibility.map((renderer) => (
                     <Renderer key={renderer.name}>
-                      {renderer.icon && <RendererIcon src={renderer.icon} />}
+                      {renderer.icon && (
+                        <RendererIcon src={renderer.icon.replace('/frameworks', '/renderers')} />
+                      )}
                       {renderer.displayName}
                     </Renderer>
                   ))}

--- a/src/content/recipes/@emotion/styled.md
+++ b/src/content/recipes/@emotion/styled.md
@@ -103,4 +103,4 @@ When you provide more than one theme, a toolbar menu will appear in the Storyboo
 
 Now you're ready to use Emotion with Storybook. 🎉
 
-If you use Emotion at work, we'd love your help making this setup even better. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/react/addons/introduction).
+If you use Emotion at work, we'd love your help making this setup even better. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/addons).

--- a/src/content/recipes/bootstrap.md
+++ b/src/content/recipes/bootstrap.md
@@ -80,4 +80,4 @@ export const decorators = [
 
 Now you're ready to use Bootstrap with Storybook. 🎉 Check out the [example repo](https://github.com/Integrayshaun/bootstrap-storybook-example) for a quick start.
 
-If you use Bootstrap at work, we'd love your feedback on the Bootstrap + Storybook experience. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/react/addons/introduction).
+If you use Bootstrap at work, we'd love your feedback on the Bootstrap + Storybook experience. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/addons).

--- a/src/content/recipes/styled-components.md
+++ b/src/content/recipes/styled-components.md
@@ -87,4 +87,4 @@ When you provide more than one theme, a toolbar menu will appear in the Storyboo
 
 Now you're ready to use styled-components with Storybook. 🎉
 
-If you use styled-components at work, we'd love your help making this setup even easier. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/react/addons/introduction).
+If you use styled-components at work, we'd love your help making this setup even easier. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/addons).

--- a/src/content/recipes/tailwindcss.md
+++ b/src/content/recipes/tailwindcss.md
@@ -154,4 +154,4 @@ This code will create a new toolbar menu to select your desired theme for your s
 
 Now you're ready to use Tailwind with Storybook. 🎉
 
-If you use Tailwind at work, we'd love your help making this setup even easier. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/react/addons/introduction).
+If you use Tailwind at work, we'd love your help making this setup even easier. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/addons).

--- a/src/content/recipes/vuetify.md
+++ b/src/content/recipes/vuetify.md
@@ -177,4 +177,4 @@ export const withVuetifyTheme = (storyFn, context) => {
 
 Now you're ready to use Vuetify with Storybook. 🎉 Check out the [example repo](https://github.com/Integrayshaun/vue3-vuetify-storybook-recipe-example) for a quick start.
 
-If you use Vuetify at work, we'd love your help making an addon that automatically applies the configuration above. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/vue/addons/introduction).
+If you use Vuetify at work, we'd love your help making an addon that automatically applies the configuration above. Join the maintainers in [Discord](https://discord.gg/storybook) to get involved, or jump into [addon docs](/docs/addons).

--- a/src/util/generateRedirects/generateRedirects.js
+++ b/src/util/generateRedirects/generateRedirects.js
@@ -1,0 +1,117 @@
+const siteMetadata = require('../../../site-metadata');
+const buildPathWithVersion = require('../build-path-with-version');
+const getReleaseBranchUrl = require('../get-release-branch-url');
+const { versions: versionsData } = require('../versions');
+const versionData = require('../version-data');
+
+const {
+  urls: { installDocsPageSlug },
+  allRenderers,
+} = siteMetadata;
+
+function parseRawRedirects(rawRedirects) {
+  const lines = rawRedirects.split('\n');
+  const redirects = {};
+
+  let currentVersion = null;
+  let currentLines = [];
+
+  lines.forEach((line) => {
+    if (line.match(/^# \d+\.\d+$/)) {
+      // Found a version line
+      if (currentVersion !== null) {
+        // Save the previous version's lines as an array
+        redirects[currentVersion] = currentLines;
+      }
+
+      // Start a new version
+      currentVersion = line.replace('# ', '').trim();
+      currentLines = [];
+    } else if (line.trim() !== '') {
+      // Add non-empty lines to the current version's lines array
+      currentLines.push(line.split(/\s+/));
+    }
+  });
+
+  // Save the lines for the last version as an array
+  if (currentVersion !== null) {
+    redirects[currentVersion] = currentLines;
+  }
+
+  return redirects;
+}
+
+function fromWithRenderer(from, renderer) {
+  const parts = from.split('/');
+  parts.splice(2, 0, renderer);
+  return parts.join('/');
+}
+
+function generateRedirects({
+  latestVersionString = versionData.latestVersionString,
+  nextVersionString = versionsData.preRelease[0]?.string || latestVersionString,
+  rawRedirects,
+  renderers = allRenderers,
+  versions = [...versionsData.stable, ...versionsData.preRelease, { string: 'next' }],
+}) {
+  const parsedRedirects = parseRawRedirects(rawRedirects);
+
+  return versions
+    .reduce((acc, { string, version }) => {
+      const isLatestLocal = string === latestVersionString;
+      const versionStringNormalized = string === 'next' ? nextVersionString : string;
+      const versionStringOverride = isLatestLocal ? '' : string;
+      const versionSlug = isLatestLocal ? '' : `/${string}`;
+      const versionBranch = isLatestLocal ? '' : getReleaseBranchUrl(versionStringNormalized);
+      const redirectCode = isLatestLocal ? 301 : 200;
+
+      Object.entries(parsedRedirects).forEach(([redirectVersion, lines]) => {
+        // Only add redirects that apply to this version
+        if (Number(redirectVersion) <= version) {
+          lines.forEach(([from, to, code]) => {
+            // 7.6 removed the renderer from docs URLs
+            if (version < 7.6) {
+              renderers.forEach((r) => {
+                acc.push(
+                  // prettier-ignore
+                  `${buildPathWithVersion(fromWithRenderer(from, r), versionStringOverride)} ${versionBranch}${buildPathWithVersion(to, versionStringOverride)} ${code}`
+                );
+              });
+            } else if (Number(redirectVersion) >= 7.6) {
+              acc.push(
+                // prettier-ignore
+                `${buildPathWithVersion(from, versionStringOverride)} ${versionBranch}${buildPathWithVersion(to, versionStringOverride)} ${code}`
+              );
+            }
+          });
+        }
+      });
+
+      acc.push(
+        // prettier-ignore
+        `/docs${versionSlug} ${versionBranch}${buildPathWithVersion(installDocsPageSlug, versionStringOverride)} ${redirectCode}`
+      );
+
+      renderers.forEach((r) => {
+        acc.push(
+          // prettier-ignore
+          `/docs${versionSlug}/${r}/* ${versionBranch}/docs${versionSlug}/:splat ${redirectCode}`
+        );
+      });
+
+      if (!isLatestLocal) {
+        acc.push(`/docs/${string}/* ${versionBranch}/docs/${versionStringNormalized}/:splat 200`);
+      } else {
+        acc.push(`/docs/${string}/* /docs/:splat 301`);
+      }
+
+      return acc;
+    }, [])
+    .concat([`/releases /releases/${latestVersionString} 301`])
+    .join('\n');
+}
+
+module.exports = {
+  parseRawRedirects,
+  generateRedirects,
+};

--- a/src/util/generateRedirects/generateRedirects.test.ts
+++ b/src/util/generateRedirects/generateRedirects.test.ts
@@ -1,0 +1,586 @@
+import { parseRawRedirects, generateRedirects } from './generateRedirects';
+
+const versions = [
+  { version: 7.6, string: '7.6', label: 'latest' },
+  { version: 7.5, string: '7.5' },
+  { version: 7.4, string: '7.4' },
+  { version: 7.3, string: '7.3' },
+  { version: 7.2, string: '7.2' },
+  { version: 7.1, string: '7.1' },
+  { version: 7, string: '7.0' },
+  { version: 6.5, string: '6.5' },
+  { version: 6.4, string: '6.4' },
+  { version: 6.3, string: '6.3' },
+  { version: 6.2, string: '6.2' },
+  { version: 6.1, string: '6.1' },
+  { version: 6, string: '6.0' },
+  { version: 8, string: '8.0', label: 'alpha' },
+  { string: 'next' },
+];
+
+const latestVersionString = '7.6';
+
+const nextVersionString = '8.0';
+
+const renderers = [
+  'react',
+  'vue',
+  'angular',
+  'web-components',
+  'ember',
+  'html',
+  'svelte',
+  'preact',
+  'qwik',
+  'solid',
+];
+
+const inputString = `
+# Multi-line preamble
+# Should not be included
+
+# 6.0
+/docs/workflows/testing-with-storybook/          /docs/writing-tests/                                   301
+/docs/workflows/unit-testing/                    /docs/writing-tests/stories-in-unit-tests/             301
+
+# 7.1
+/docs/writing-tests/importing-stories-in-tests/  /docs/writing-tests/stories-in-unit-tests/             301
+
+# 7.6
+/docs/writing-stories/introduction               /docs/writing-stories                                  301
+/docs/writing-docs/introduction                  /docs/writing-docs                                     301
+`;
+
+function statefulGenerateRedirects(rawRedirects: string) {
+  return generateRedirects({
+    rawRedirects,
+    latestVersionString,
+    nextVersionString,
+    renderers,
+    versions,
+  });
+}
+
+describe('parseRawRedirects', () => {
+  it('parses', () => {
+    const result = parseRawRedirects(inputString);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "6.0": [
+          [
+            "/docs/workflows/testing-with-storybook/",
+            "/docs/writing-tests/",
+            "301",
+          ],
+          [
+            "/docs/workflows/unit-testing/",
+            "/docs/writing-tests/stories-in-unit-tests/",
+            "301",
+          ],
+        ],
+        "7.1": [
+          [
+            "/docs/writing-tests/importing-stories-in-tests/",
+            "/docs/writing-tests/stories-in-unit-tests/",
+            "301",
+          ],
+        ],
+        "7.6": [
+          [
+            "/docs/writing-stories/introduction",
+            "/docs/writing-stories",
+            "301",
+          ],
+          [
+            "/docs/writing-docs/introduction",
+            "/docs/writing-docs",
+            "301",
+          ],
+        ],
+      }
+    `);
+  });
+});
+
+describe('generateRedirects', () => {
+  it('generates', () => {
+    const result = statefulGenerateRedirects(inputString);
+    expect(result).toMatchInlineSnapshot(`
+      "/docs/writing-stories/introduction /docs/writing-stories 301
+      /docs/writing-docs/introduction /docs/writing-docs 301
+      /docs /docs/get-started/install/ 301
+      /docs/react/* /docs/:splat 301
+      /docs/vue/* /docs/:splat 301
+      /docs/angular/* /docs/:splat 301
+      /docs/web-components/* /docs/:splat 301
+      /docs/ember/* /docs/:splat 301
+      /docs/html/* /docs/:splat 301
+      /docs/svelte/* /docs/:splat 301
+      /docs/preact/* /docs/:splat 301
+      /docs/qwik/* /docs/:splat 301
+      /docs/solid/* /docs/:splat 301
+      /docs/7.6/* /docs/:splat 301
+      /docs/7.5/react/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/vue/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/angular/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/web-components/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/ember/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/html/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/svelte/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/preact/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/qwik/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/solid/workflows/testing-with-storybook/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/ 301
+      /docs/7.5/react/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/vue/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/angular/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/web-components/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/ember/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/html/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/svelte/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/preact/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/qwik/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/solid/workflows/unit-testing/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/react/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/vue/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/angular/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/web-components/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/ember/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/html/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/svelte/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/preact/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/qwik/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5/solid/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.5 https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/get-started/install/ 200
+      /docs/7.5/react/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/vue/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/angular/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/web-components/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/ember/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/html/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/svelte/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/preact/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/qwik/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/solid/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.5/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
+      /docs/7.4/react/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/vue/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/angular/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/web-components/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/ember/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/html/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/svelte/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/preact/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/qwik/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/solid/workflows/testing-with-storybook/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/ 301
+      /docs/7.4/react/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/vue/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/angular/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/web-components/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/ember/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/html/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/svelte/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/preact/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/qwik/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/solid/workflows/unit-testing/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/react/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/vue/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/angular/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/web-components/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/ember/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/html/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/svelte/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/preact/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/qwik/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4/solid/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.4 https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/get-started/install/ 200
+      /docs/7.4/react/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/vue/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/angular/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/web-components/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/ember/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/html/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/svelte/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/preact/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/qwik/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/solid/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.4/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
+      /docs/7.3/react/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/vue/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/angular/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/web-components/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/ember/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/html/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/svelte/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/preact/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/qwik/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/solid/workflows/testing-with-storybook/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/ 301
+      /docs/7.3/react/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/vue/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/angular/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/web-components/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/ember/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/html/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/svelte/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/preact/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/qwik/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/solid/workflows/unit-testing/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/react/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/vue/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/angular/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/web-components/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/ember/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/html/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/svelte/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/preact/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/qwik/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3/solid/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.3 https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/get-started/install/ 200
+      /docs/7.3/react/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/vue/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/angular/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/web-components/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/ember/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/html/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/svelte/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/preact/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/qwik/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/solid/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.3/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
+      /docs/7.2/react/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/vue/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/angular/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/web-components/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/ember/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/html/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/svelte/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/preact/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/qwik/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/solid/workflows/testing-with-storybook/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/ 301
+      /docs/7.2/react/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/vue/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/angular/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/web-components/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/ember/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/html/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/svelte/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/preact/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/qwik/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/solid/workflows/unit-testing/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/react/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/vue/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/angular/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/web-components/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/ember/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/html/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/svelte/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/preact/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/qwik/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2/solid/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.2 https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/get-started/install/ 200
+      /docs/7.2/react/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/vue/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/angular/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/web-components/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/ember/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/html/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/svelte/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/preact/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/qwik/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/solid/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.2/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
+      /docs/7.1/react/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/vue/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/angular/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/web-components/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/ember/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/html/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/svelte/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/preact/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/qwik/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/solid/workflows/testing-with-storybook/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/ 301
+      /docs/7.1/react/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/vue/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/angular/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/web-components/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/ember/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/html/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/svelte/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/preact/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/qwik/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/solid/workflows/unit-testing/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/react/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/vue/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/angular/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/web-components/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/ember/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/html/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/svelte/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/preact/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/qwik/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1/solid/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.1 https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/get-started/install/ 200
+      /docs/7.1/react/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/vue/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/angular/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/web-components/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/ember/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/html/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/svelte/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/preact/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/qwik/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/solid/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.1/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
+      /docs/7.0/react/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/vue/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/angular/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/web-components/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/ember/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/html/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/svelte/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/preact/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/qwik/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/solid/workflows/testing-with-storybook/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/ 301
+      /docs/7.0/react/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/vue/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/angular/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/web-components/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/ember/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/html/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/svelte/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/preact/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/qwik/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0/solid/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/7.0 https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/get-started/install/ 200
+      /docs/7.0/react/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/vue/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/angular/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/web-components/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/ember/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/html/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/svelte/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/preact/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/qwik/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/solid/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/7.0/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
+      /docs/6.5/react/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/vue/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/angular/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/web-components/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/ember/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/html/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/svelte/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/preact/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/qwik/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/solid/workflows/testing-with-storybook/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/ 301
+      /docs/6.5/react/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/vue/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/angular/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/web-components/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/ember/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/html/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/svelte/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/preact/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/qwik/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5/solid/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.5 https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/get-started/install/ 200
+      /docs/6.5/react/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/vue/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/angular/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/web-components/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/ember/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/html/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/svelte/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/preact/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/qwik/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/solid/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.5/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
+      /docs/6.4/react/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/vue/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/angular/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/web-components/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/ember/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/html/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/svelte/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/preact/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/qwik/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/solid/workflows/testing-with-storybook/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/ 301
+      /docs/6.4/react/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/vue/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/angular/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/web-components/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/ember/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/html/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/svelte/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/preact/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/qwik/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4/solid/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.4 https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/get-started/install/ 200
+      /docs/6.4/react/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/vue/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/angular/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/web-components/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/ember/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/html/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/svelte/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/preact/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/qwik/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/solid/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.4/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
+      /docs/6.3/react/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/vue/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/angular/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/web-components/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/ember/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/html/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/svelte/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/preact/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/qwik/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/solid/workflows/testing-with-storybook/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/ 301
+      /docs/6.3/react/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/vue/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/angular/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/web-components/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/ember/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/html/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/svelte/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/preact/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/qwik/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3/solid/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.3 https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/get-started/install/ 200
+      /docs/6.3/react/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/vue/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/angular/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/web-components/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/ember/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/html/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/svelte/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/preact/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/qwik/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/solid/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.3/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
+      /docs/6.2/react/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/vue/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/angular/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/web-components/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/ember/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/html/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/svelte/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/preact/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/qwik/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/solid/workflows/testing-with-storybook/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/ 301
+      /docs/6.2/react/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/vue/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/angular/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/web-components/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/ember/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/html/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/svelte/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/preact/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/qwik/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2/solid/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.2 https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/get-started/install/ 200
+      /docs/6.2/react/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/vue/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/angular/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/web-components/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/ember/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/html/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/svelte/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/preact/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/qwik/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/solid/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.2/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
+      /docs/6.1/react/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/vue/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/angular/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/web-components/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/ember/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/html/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/svelte/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/preact/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/qwik/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/solid/workflows/testing-with-storybook/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/ 301
+      /docs/6.1/react/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/vue/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/angular/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/web-components/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/ember/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/html/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/svelte/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/preact/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/qwik/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1/solid/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.1 https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/get-started/install/ 200
+      /docs/6.1/react/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/vue/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/angular/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/web-components/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/ember/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/html/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/svelte/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/preact/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/qwik/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/solid/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.1/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
+      /docs/6.0/react/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/vue/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/angular/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/web-components/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/ember/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/html/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/svelte/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/preact/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/qwik/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/solid/workflows/testing-with-storybook/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/ 301
+      /docs/6.0/react/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/vue/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/angular/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/web-components/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/ember/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/html/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/svelte/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/preact/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/qwik/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0/solid/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
+      /docs/6.0 https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/get-started/install/ 200
+      /docs/6.0/react/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/vue/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/angular/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/web-components/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/ember/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/html/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/svelte/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/preact/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/qwik/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/solid/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/6.0/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
+      /docs/8.0/writing-stories/introduction https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/writing-stories 301
+      /docs/8.0/writing-docs/introduction https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/writing-docs 301
+      /docs/8.0 https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/get-started/install/ 200
+      /docs/8.0/react/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/vue/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/angular/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/web-components/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/ember/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/html/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/svelte/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/preact/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/qwik/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/solid/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/8.0/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /docs/next https://release-8-0--storybook-frontpage.netlify.app/docs/next/get-started/install/ 200
+      /docs/next/react/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/vue/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/angular/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/web-components/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/ember/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/html/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/svelte/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/preact/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/qwik/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/solid/* https://release-8-0--storybook-frontpage.netlify.app/docs/next/:splat 200
+      /docs/next/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
+      /releases /releases/7.6 301"
+    `);
+  });
+});

--- a/src/util/redirects-raw.txt
+++ b/src/util/redirects-raw.txt
@@ -31,7 +31,7 @@
 /docs/configure/babel                            /docs/configure/compilers                                                      301
 /docs/configure/webpack                          /docs/builders/webpack                                                         301
 /docs/builders/overview                          /docs/builders                                                                 301
-/docs/api/addons                                 /docs/addons/introduction                                                      301
+/docs/api/addons                                 /docs/addons                                                                   301
 /docs/api/addons-api                             /docs/addons/addons-api                                                        301
 /docs/api/mdx                                    /docs/writing-docs/mdx                                                         301
 /docs/api/presets                                /docs/addons/writing-presets                                                   301

--- a/src/util/redirects-raw.txt
+++ b/src/util/redirects-raw.txt
@@ -1,40 +1,52 @@
-/docs/why-storybook/                             /docs/get-started/why-storybook                                                301
-/docs/get-started/introduction                   /docs/get-started/install                                                      301
-/docs/writing-stories/introduction               /docs/writing-stories                                                          301
-/docs/writing-docs/introduction                  /docs/writing-docs                                                             301
-/docs/writing-docs/docs-page                     /docs/writing-docs/autodocs                                                    301
-/docs/writing-docs/doc-block-argstable           /docs/api/doc-block-controls                                                   301
-/docs/writing-docs/doc-block-canvas              /docs/api/doc-block-canvas                                                     301
-/docs/writing-docs/doc-block-colorpalette        /docs/api/doc-block-colorpalette                                               301
-/docs/writing-docs/doc-block-description         /docs/api/doc-block-description                                                301
-/docs/writing-docs/doc-block-icongallery         /docs/api/doc-block-icongallery                                                301
-/docs/writing-docs/doc-block-source              /docs/api/doc-block-source                                                     301
-/docs/writing-docs/doc-block-story               /docs/api/doc-block-story                                                      301
-/docs/writing-docs/doc-block-typeset             /docs/api/doc-block-typeset                                                    301
-/docs/writing-tests/introduction                 /docs/writing-tests/                                                           301
-/docs/writing-tests/importing-stories-in-tests/  /docs/writing-tests/stories-in-unit-tests/                                     301
-/docs/workflows/testing-with-storybook/          /docs/writing-tests/                                                           301
-/docs/workflows/unit-testing/                    /docs/writing-tests/stories-in-unit-tests/                                     301
-/docs/workflows/visual-testing/                  /docs/writing-tests/visual-testing/                                            301
-/docs/workflows/interaction-testing/             /docs/writing-tests/interaction-testing/                                       301
-/docs/workflows/snapshot-testing/                /docs/writing-tests/snapshot-testing/                                          301
-/docs/workflows/build-pages-with-storybook/      /docs/writing-stories/build-pages-with-storybook/                              301
-/docs/workflows/stories-for-multiple-components/ /docs/writing-stories/stories-for-multiple-components/                         301
-/docs/workflows/publish-storybook/               /docs/sharing/publish-storybook/                                               301
-/docs/workflows/storybook-composition/           /docs/sharing/storybook-composition/                                           301
-/docs/workflows/package-composition/             /docs/sharing/package-composition/                                             301
-/docs/workflows/faq/                             /docs/faq/                                                                     301
-/docs/essentials/introduction                    /docs/essentials                                                               301
-/docs/addons/introduction                        /docs/addons                                                                   301
-/docs/addons/addon-catalog                       /docs/addons/integration-catalog                                               301
-/docs/configure/overview                         /docs/configure                                                                301
-/docs/configure/babel                            /docs/configure/compilers                                                      301
-/docs/configure/webpack                          /docs/builders/webpack                                                         301
-/docs/builders/overview                          /docs/builders                                                                 301
-/docs/api/addons                                 /docs/addons                                                                   301
-/docs/api/addons-api                             /docs/addons/addons-api                                                        301
-/docs/api/mdx                                    /docs/writing-docs/mdx                                                         301
-/docs/api/presets                                /docs/addons/writing-presets                                                   301
-/docs/api/frameworks-feature-support             /docs/configure/frameworks-feature-support                                     301
-/docs/api/argtypes                               /docs/api/arg-types                                                            301
-/docs/contribute/how-to-contribute               /docs/contribute                                                               301
+# The redirects here will have an appropriate version (and sometimes framework) added to the `from` (first path in the line)
+# They are broken down by the version at which the `to` (second path in the line) was added
+
+# 6.0
+/docs/workflows/testing-with-storybook/          /docs/writing-tests/                                   301
+/docs/workflows/unit-testing/                    /docs/writing-tests/stories-in-unit-tests/             301
+/docs/workflows/visual-testing/                  /docs/writing-tests/visual-testing/                    301
+/docs/workflows/interaction-testing/             /docs/writing-tests/interaction-testing/               301
+/docs/workflows/snapshot-testing/                /docs/writing-tests/snapshot-testing/                  301
+/docs/workflows/build-pages-with-storybook/      /docs/writing-stories/build-pages-with-storybook/      301
+/docs/workflows/stories-for-multiple-components/ /docs/writing-stories/stories-for-multiple-components/ 301
+/docs/workflows/publish-storybook/               /docs/sharing/publish-storybook/                       301
+/docs/workflows/storybook-composition/           /docs/sharing/storybook-composition/                   301
+/docs/workflows/package-composition/             /docs/sharing/package-composition/                     301
+/docs/workflows/faq/                             /docs/faq/                                             301
+
+# 6.5
+/docs/configure/webpack                          /docs/builders/webpack                                 301
+/docs/api/addons                                 /docs/addons                                           301
+/docs/api/addons-api                             /docs/addons/addons-api                                301
+/docs/api/presets                                /docs/addons/writing-presets                           301
+/docs/addons/addon-catalog                       /docs/addons/integration-catalog                       301
+/docs/api/mdx                                    /docs/writing-docs/mdx                                 301
+/docs/why-storybook/                             /docs/get-started/why-storybook                        301
+/docs/get-started/introduction                   /docs/get-started/install                              301
+
+# 7.0
+/docs/writing-docs/docs-page                     /docs/writing-docs/autodocs                            301
+/docs/writing-docs/doc-block-argstable           /docs/api/doc-block-controls                           301
+/docs/writing-docs/doc-block-canvas              /docs/api/doc-block-canvas                             301
+/docs/writing-docs/doc-block-colorpalette        /docs/api/doc-block-colorpalette                       301
+/docs/writing-docs/doc-block-description         /docs/api/doc-block-description                        301
+/docs/writing-docs/doc-block-icongallery         /docs/api/doc-block-icongallery                        301
+/docs/writing-docs/doc-block-source              /docs/api/doc-block-source                             301
+/docs/writing-docs/doc-block-story               /docs/api/doc-block-story                              301
+/docs/writing-docs/doc-block-typeset             /docs/api/doc-block-typeset                            301
+/docs/api/frameworks-feature-support             /docs/configure/frameworks-feature-support             301
+/docs/api/argtypes                               /docs/api/arg-types                                    301
+
+# 7.1
+/docs/writing-tests/importing-stories-in-tests/  /docs/writing-tests/stories-in-unit-tests/             301
+
+# 7.6
+/docs/writing-stories/introduction               /docs/writing-stories                                  301
+/docs/writing-docs/introduction                  /docs/writing-docs                                     301
+/docs/writing-tests/introduction                 /docs/writing-tests/                                   301
+/docs/essentials/introduction                    /docs/essentials                                       301
+/docs/addons/introduction                        /docs/addons                                           301
+/docs/configure/overview                         /docs/configure                                        301
+/docs/builders/overview                          /docs/builders                                         301
+/docs/contribute/how-to-contribute               /docs/contribute                                       301
+/docs/configure/babel                            /docs/configure/compilers                              301

--- a/static/_redirects
+++ b/static/_redirects
@@ -2,7 +2,7 @@
 
 # Older (prev 5.0 doc URLs)
 /basics/quick-start-guide                   /docs/get-started/install/                                                                          301
-/basics/slow-start-guide                    /docs/configure/overview/                                                                           301
+/basics/slow-start-guide                    /docs/configure/                                                                                    301
 /basics/guide-react                         /docs/get-started/install/                                                                          301
 /basics/guide-react-native                  https://github.com/storybookjs/react-native#storybook-for-react-native                              301
 /basics/guide-vue                           /docs/get-started/install/                                                                          301
@@ -12,7 +12,7 @@
 /basics/guide-riot                          /docs/get-started/install/                                                                          301
 /basics/guide-html                          /docs/get-started/install/                                                                          301
 /docs/basics/quick-start-guide              /docs/get-started/install/                                                                          301
-/docs/basics/slow-start-guide               /docs/configure/overview/                                                                           301
+/docs/basics/slow-start-guide               /docs/configure/                                                                                    301
 /docs/basics/guide-react                    /docs/get-started/install/                                                                          301
 /docs/basics/guide-react-native             https://github.com/storybookjs/react-native#storybook-for-react-native                              301
 /docs/basics/guide-vue                      /docs/get-started/install/                                                                          301
@@ -37,7 +37,7 @@
 /docs/examples/                             /docs/get-started/examples/                                                                         301
 
 /docs/guides/quick-start-guide/             /docs/get-started/install/                                                                          301
-/docs/guides/slow-start-guide/              /docs/configure/overview/                                                                           301
+/docs/guides/slow-start-guide/              /docs/configure/                                                                                    301
 /docs/guides/guide-html/                    /docs/get-started/install/                                                                          301
 /docs/guides/guide-react/                   /docs/get-started/install/                                                                          301
 /docs/guides/guide-react-native/            https://github.com/storybookjs/react-native#storybook-for-react-native                              301
@@ -55,11 +55,11 @@
 /docs/guides/guide-svelte/                  /docs/get-started/install/                                                                          301
 /docs/guides/guide-preact/                  /docs/get-started/install/                                                                          301
 
-/docs/configurations/overview/              /docs/configure/overview/                                                                           301
+/docs/configurations/overview/              /docs/configure/                                                                                    301
 /docs/configurations/options-parameter/     /docs/configure/features-and-behavior/                                                              301
-/docs/configurations/default-config/        /docs/configure/overview/                                                                           301
+/docs/configurations/default-config/        /docs/configure/                                                                                    301
 /docs/configurations/custom-webpack-config/ /docs/builders/webpack/                                                                             301
-/docs/configurations/custom-babel-config/   /docs/configure/compilers/                                                                              301
+/docs/configurations/custom-babel-config/   /docs/configure/compilers/                                                                          301
 /docs/configurations/typescript-config/     /docs/configure/typescript/                                                                         301
 /docs/configurations/add-custom-head-tags/  /docs/configure/story-rendering#adding-to-head                                                      301
 /docs/configurations/add-custom-body/       /docs/configure/story-rendering#adding-to-body                                                      301
@@ -71,12 +71,11 @@
 /docs/formats/component-story-format/       /docs/api/csf/                                                                                      301
 /docs/formats/storiesof-api/                https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md                       301
 /docs/formats/mdx-syntax/                   /docs/api/mdx/                                                                                      301
-/docs/testing/react-ui-testing/             /docs/writing-tests/introduction/                                                                   301
+/docs/testing/react-ui-testing/             /docs/writing-tests/                                                                                301
 /docs/testing/structural-testing/           /docs/writing-tests/snapshot-testing/                                                               301
 /docs/testing/interaction-testing/          /docs/writing-tests/interaction-testing/                                                            301
 /docs/testing/automated-visual-testing/     /docs/writing-tests/visual-testing/                                                                 301
-/docs/testing/manual-testing/               /docs/writing-tests/introduction/                                                                   301
-/docs/addons/introduction/                  /docs/addons/introduction/                                                                          301
+/docs/testing/manual-testing/               /docs/writing-tests/                                                                                301
 /docs/addons/using-addons/                  /docs/addons/install-addons/                                                                        301
 /docs/addons/writing-addons/                /docs/addons/writing-addons/                                                                        301
 /addons/writing-addons/                     /docs/addons/writing-addons/                                                                        301


### PR DESCRIPTION
- Fix FrameworkSupportTable
- Fix broken renderer icons in AddonsDetailScreen
- Remove renderer from various static URLs
    - Also remove `/introduction` and `/overview`
- Update generated redirects to respect versions
    - `redirects-raw` is now broken up by version the redirect was added
    - Generated redirects include version and possibly renderer, as appropriate for the version