### PR TITLE
Handle snippets with multiple code blocks

### DIFF
--- a/src/components/screens/DocsScreen/CodeSnippets/fetch-snippets.utils.tsx
+++ b/src/components/screens/DocsScreen/CodeSnippets/fetch-snippets.utils.tsx
@@ -64,6 +64,24 @@ const getSnippetTabName = (path: string) => {
   }
   return prettifyName(name);
 };
+
+/**
+ * 1. ModuleComponent is (due to MDX) a React component.
+ * 2. That component renders one or more <pre> tags with a <code> tag inside.
+ * 3. The <code> tag contains the actual code snippet string.
+ */
+function extractContentFromModule(module) {
+  function extractContentFromCodeBlock(block) {
+    return block.props.children.props.children;
+  }
+
+  const containedCodeBlocks = module({ components: {} }).props.children;
+
+  return Array.isArray(containedCodeBlocks)
+    ? containedCodeBlocks.map(extractContentFromCodeBlock).join('\n')
+    : extractContentFromCodeBlock(containedCodeBlocks);
+}
+
 export interface SnippetObject {
   content: string;
   id: string;
@@ -125,12 +143,7 @@ export const fetchDocsSnippets = async (
       }
 
       const [title, content] = parseSnippetContent(
-        /**
-         * 1. ModuleComponent is (due to MDX) a React component.
-         * 2. That component renders a <pre> tag with a <code> tag inside.
-         * 3. The <code> tag contains the actual code snippet string.
-         */
-        ModuleComponent({ components: {} }).props.children.props.children.props.children,
+        extractContentFromModule(ModuleComponent),
         isTerminal
       );
 


### PR DESCRIPTION
### What I did

This fix effectively stitches together a snippet that contains multiple code blocks, like this:

````mdx
```js
// Button.stories.js

import Button from './Button.svelte';
import MarginDecorator from './MarginDecorator.svelte';

export default {
  component: Button,
  decorators: [() => MarginDecorator],
};

// Your stories here.

// Don't forget to use the component you're testing and not the MarginDecorator component
```

```html
<!-- MarginDecorator.svelte -->

<div>
  <slot />
</div>

<style>
  div {
    margin: 3em;
  }
</style>
```
````

Into a unified code block, using the language of the first one:

````mdx
```js
// Button.stories.js

import Button from './Button.svelte';
import MarginDecorator from './MarginDecorator.svelte';

export default {
  component: Button,
  decorators: [() => MarginDecorator],
};

// Your stories here.

// Don't forget to use the component you're testing and not the MarginDecorator component

<!-- MarginDecorator.svelte -->

<div>
  <slot />
</div>

<style>
  div {
    margin: 3em;
  }
</style>
```
````

The end result then displays like:

<img width="622" alt="" src="https://github.com/storybookjs/frontpage/assets/486540/e3311c6a-7187-426e-b33d-f9723c1b12c2">

The syntax highlighting for the second portion is not perfect. This solution compromises that for simplicity of implementation, as there are currently only two examples of multi-code block snippets.

### How to test

There are literally only two snippets that meet the criteria requiring this fix and they're both on the `/writing-stories/decorators` page and apply to the Svelte renderer.

1. Open the [deploy preview's Decorators page](https://deploy-preview-644--storybook-frontpage.netlify.app/docs/writing-stories/decorators)
1. Confirm that the snippets look correct
1. Select the Svelte renderer
1. Confirm that these snippets look correct
    1. Under the [**Wrap stories with extra markup** heading](https://deploy-preview-644--storybook-frontpage.netlify.app/docs/writing-stories/decorators#wrap-stories-with-extra-markup)
    1. Under the [**Component decorators** heading](https://deploy-preview-644--storybook-frontpage.netlify.app/docs/writing-stories/decorators#component-decorators)