### PR TITLE
add another redirect for plausible (blog specific)

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -99,6 +99,7 @@
 # Plausible analytics
 /js/script.js                               https://plausible.io/js/script.js                                                                   200
 /api/event                                  https://plausible.io/api/event                                                                      200
+/proxy/api/event                            https://plausible.io/api/event                                                                      200
 
 # We can't use updateRedirectsFile for these because it adds the version to the destination
 /docs/react/get-started/examples            /showcase                                                                                           301


### PR DESCRIPTION
The blog requires a slightly different redirect because the `/api` endpoint is already used for something else. 