### PR TITLE
Update "install page" to `/docs/get-started`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,6 @@ const path = require('path');
 const { global } = require('@storybook/design-system');
 const siteMetadata = require('./site-metadata');
 const getReleaseBranchUrl = require('./src/util/get-release-branch-url');
-const versionData = require('./src/util/version-data');
 const { versionsWithToc } = require('./src/util/versions');
 
 require('dotenv').config({
@@ -10,16 +9,13 @@ require('dotenv').config({
 });
 
 module.exports = {
-  siteMetadata: {
-    ...siteMetadata,
-    ...versionData,
-  },
+  siteMetadata,
   flags: {
     FAST_DEV: true,
     QUERY_ON_DEMAND: true,
   },
-  ...(!versionData.isLatest
-    ? { assetPrefix: getReleaseBranchUrl(versionData.versionString) }
+  ...(!siteMetadata.isLatest
+    ? { assetPrefix: getReleaseBranchUrl(siteMetadata.versionString) }
     : undefined),
   plugins: [
     'gatsby-plugin-react-helmet',
@@ -165,14 +161,14 @@ module.exports = {
           '/*': [
             'X-XSS-Protection: 1; mode=block',
             'X-Content-Type-Options: nosniff',
-            ...(!versionData.isLatest ? ['Access-Control-Allow-Origin: *'] : []),
+            ...(!siteMetadata.isLatest ? ['Access-Control-Allow-Origin: *'] : []),
           ],
           '/versions.json': [
             'Access-Control-Allow-Origin: *',
             'Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept',
           ],
-          ...(!versionData.isLatest && {
-            [`/docs/${versionData.versionString}/*`]: ['X-Robots-Tag: noindex'],
+          ...(!siteMetadata.isLatest && {
+            [`/docs/${siteMetadata.versionString}/*`]: ['X-Robots-Tag: noindex'],
           }),
         },
         // Do not use the default security headers. Use those we have defined above.
@@ -186,7 +182,7 @@ module.exports = {
         component: require.resolve('./src/components/layout/PageLayout'),
       },
     },
-    ...(versionData.isLatest
+    ...(siteMetadata.isLatest
       ? [
           {
             resolve: `gatsby-plugin-sitemap`,
@@ -269,7 +265,7 @@ module.exports = {
 
                   createDocsPageEntries(
                     toc,
-                    string !== versionData.latestVersionString ? `/docs/${string}` : '/docs'
+                    string !== siteMetadata.latestVersionString ? `/docs/${string}` : '/docs'
                   );
                 });
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,11 +13,6 @@ const sourceDXData = require('./src/util/source-dx-data');
 const { versions, versionsWithToc } = require('./src/util/versions');
 const createIntegrationsPages = require('./src/util/create-integrations-pages');
 const createHomePage = require('./src/util/create-home-page');
-const siteMetadata = require('./site-metadata');
-
-const {
-  urls: { installDocsPageSlug },
-} = siteMetadata;
 
 const docsPagesSlugs = [];
 
@@ -175,7 +170,6 @@ exports.createPages = ({ actions, graphql }) => {
                         nextTocItem.type === 'bullet-link' && {
                           nextTocItem,
                         }),
-                      isInstallPage: slug === installDocsPageSlug,
                     },
                   });
 

--- a/site-metadata.js
+++ b/site-metadata.js
@@ -3,6 +3,7 @@ const {
   communityFrameworks: communityRenderers,
   featureGroups,
 } = require('./src/content/docs/frameworks');
+const versionData = require('./src/util/version-data');
 
 const isDeployPreview = process.env.CONTEXT === 'deploy-preview';
 const homepageUrl = isDeployPreview ? process.env.DEPLOY_PRIME_URL : 'https://storybook.js.org';
@@ -13,6 +14,7 @@ const essentialsBase = '/docs/react/essentials';
 const contributeUrl = `${docsUrl}/react/contribute/how-to-contribute`;
 
 const siteMetadata = {
+  ...versionData,
   title: 'Storybook: Frontend workshop for UI development',
   description: `Storybook is a frontend workshop for building UI components and pages in isolation. Thousands of teams use it for UI development, testing, and documentation. It’s open source and free.`,
   ogImage: '/images/social/open-graph.jpg',
@@ -82,7 +84,8 @@ const siteMetadata = {
     team: `/team/`,
     addonsApi: '/docs/react/addons/addons-api/',
     // This slug is also used to exclude some pages from the sitemap in gatsby-config.js
-    installDocsPageSlug: '/docs/get-started/install/',
+    installDocsPageSlug:
+      versionData.version >= 8 ? '/docs/get-started/' : '/docs/get-started/install/',
 
     // Social
     blog: `https://storybook.js.org/blog`,

--- a/src/components/screens/DocsScreen/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen/DocsScreen.tsx
@@ -229,7 +229,7 @@ function DocsScreen({ data, pageContext, location }) {
     urls: { homepageUrl },
     versionString,
   } = useSiteMetadata();
-  const { docsToc, fullPath, slug, tocItem, nextTocItem, isInstallPage } = pageContext;
+  const { docsToc, fullPath, slug, tocItem, nextTocItem } = pageContext;
 
   const {
     codeLanguage: [codeLanguage],
@@ -349,7 +349,7 @@ function DocsScreen({ data, pageContext, location }) {
         )}
         <Content>
           <Header>
-            <Title>{isInstallPage ? `${title} for ${stylizeRenderer(renderer)}` : title}</Title>
+            <Title>{title}</Title>
             {!hideRendererSelector && (
               <RendererSelector
                 coreRenderers={coreRenderers}

--- a/src/components/screens/IndexScreen/Develop.js
+++ b/src/components/screens/IndexScreen/Develop.js
@@ -20,6 +20,7 @@ import buildPathWithVersion from '../../../util/build-path-with-version';
 
 const {
   urls: { installDocsPageSlug },
+  version,
 } = siteMetadata;
 
 const { subheading, breakpoints, pageMargins } = styles;
@@ -38,11 +39,13 @@ const Wrapper = styled.section`
   }
 `;
 
-const featuredRenderers = ['react', 'vue', 'angular', 'web-components', 'html'];
+const featuredRenderers = ['react', 'vue', 'angular', 'web-components', 'svelte', 'html'];
 const rendererIntegrations = featuredRenderers.map((renderer) => ({
   name: renderer,
   image: `/renderers/logo-${renderer === 'web-components' ? 'web-components-alt' : renderer}.svg`,
-  href: `${buildPathWithVersion(installDocsPageSlug)}?renderer=${renderer}`,
+  // In 8+ docs, we link to the get-started page, which is renderer-agnostic, instead of the install guide, which is not.
+  // prettier-ignore
+  href: `${buildPathWithVersion(installDocsPageSlug)}${version >= 8 ? '' : `?renderer=${renderer}`}`,
   ButtonWrapper: GatsbyLinkWrapper,
 }));
 
@@ -227,7 +230,7 @@ export function Develop({ docs, startOpen, ...props }) {
         actions={
           <div>
             <MadeFor>Made for</MadeFor>
-            <IntegrationsList integrations={rendererIntegrations} overflowLabel="+ 7" inverse />
+            <IntegrationsList integrations={rendererIntegrations} overflowLabel="+ 6" inverse />
           </div>
         }
       />

--- a/src/util/generateRedirects/generateRedirects.test.ts
+++ b/src/util/generateRedirects/generateRedirects.test.ts
@@ -169,7 +169,7 @@ describe('generateRedirects', () => {
       /docs/solid/writing-docs/introduction /docs/writing-docs 301
 
 
-      /docs /docs/get-started/install/ 301
+      /docs /docs/get-started/ 301
       /docs/react/* /docs/:splat 301
       /docs/vue/* /docs/:splat 301
       /docs/angular/* /docs/:splat 301
@@ -218,7 +218,7 @@ describe('generateRedirects', () => {
       /docs/7.5/solid/writing-tests/importing-stories-in-tests/ https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/7.5 https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/get-started/install/ 200
+      /docs/7.5 https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/get-started/ 200
       /docs/7.5/react/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
       /docs/7.5/vue/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
       /docs/7.5/angular/* https://release-7-5--storybook-frontpage.netlify.app/docs/7.5/:splat 200
@@ -267,7 +267,7 @@ describe('generateRedirects', () => {
       /docs/7.4/solid/writing-tests/importing-stories-in-tests/ https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/7.4 https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/get-started/install/ 200
+      /docs/7.4 https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/get-started/ 200
       /docs/7.4/react/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
       /docs/7.4/vue/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
       /docs/7.4/angular/* https://release-7-4--storybook-frontpage.netlify.app/docs/7.4/:splat 200
@@ -316,7 +316,7 @@ describe('generateRedirects', () => {
       /docs/7.3/solid/writing-tests/importing-stories-in-tests/ https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/7.3 https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/get-started/install/ 200
+      /docs/7.3 https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/get-started/ 200
       /docs/7.3/react/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
       /docs/7.3/vue/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
       /docs/7.3/angular/* https://release-7-3--storybook-frontpage.netlify.app/docs/7.3/:splat 200
@@ -365,7 +365,7 @@ describe('generateRedirects', () => {
       /docs/7.2/solid/writing-tests/importing-stories-in-tests/ https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/7.2 https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/get-started/install/ 200
+      /docs/7.2 https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/get-started/ 200
       /docs/7.2/react/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
       /docs/7.2/vue/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
       /docs/7.2/angular/* https://release-7-2--storybook-frontpage.netlify.app/docs/7.2/:splat 200
@@ -414,7 +414,7 @@ describe('generateRedirects', () => {
       /docs/7.1/solid/writing-tests/importing-stories-in-tests/ https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/7.1 https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/get-started/install/ 200
+      /docs/7.1 https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/get-started/ 200
       /docs/7.1/react/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
       /docs/7.1/vue/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
       /docs/7.1/angular/* https://release-7-1--storybook-frontpage.netlify.app/docs/7.1/:splat 200
@@ -452,7 +452,7 @@ describe('generateRedirects', () => {
       /docs/7.0/solid/workflows/unit-testing/ https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/7.0 https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/get-started/install/ 200
+      /docs/7.0 https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/get-started/ 200
       /docs/7.0/react/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
       /docs/7.0/vue/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
       /docs/7.0/angular/* https://release-7-0--storybook-frontpage.netlify.app/docs/7.0/:splat 200
@@ -490,7 +490,7 @@ describe('generateRedirects', () => {
       /docs/6.5/solid/workflows/unit-testing/ https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/6.5 https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/get-started/install/ 200
+      /docs/6.5 https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/get-started/ 200
       /docs/6.5/react/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
       /docs/6.5/vue/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
       /docs/6.5/angular/* https://release-6-5--storybook-frontpage.netlify.app/docs/6.5/:splat 200
@@ -528,7 +528,7 @@ describe('generateRedirects', () => {
       /docs/6.4/solid/workflows/unit-testing/ https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/6.4 https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/get-started/install/ 200
+      /docs/6.4 https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/get-started/ 200
       /docs/6.4/react/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
       /docs/6.4/vue/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
       /docs/6.4/angular/* https://release-6-4--storybook-frontpage.netlify.app/docs/6.4/:splat 200
@@ -566,7 +566,7 @@ describe('generateRedirects', () => {
       /docs/6.3/solid/workflows/unit-testing/ https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/6.3 https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/get-started/install/ 200
+      /docs/6.3 https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/get-started/ 200
       /docs/6.3/react/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
       /docs/6.3/vue/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
       /docs/6.3/angular/* https://release-6-3--storybook-frontpage.netlify.app/docs/6.3/:splat 200
@@ -604,7 +604,7 @@ describe('generateRedirects', () => {
       /docs/6.2/solid/workflows/unit-testing/ https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/6.2 https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/get-started/install/ 200
+      /docs/6.2 https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/get-started/ 200
       /docs/6.2/react/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
       /docs/6.2/vue/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
       /docs/6.2/angular/* https://release-6-2--storybook-frontpage.netlify.app/docs/6.2/:splat 200
@@ -642,7 +642,7 @@ describe('generateRedirects', () => {
       /docs/6.1/solid/workflows/unit-testing/ https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/6.1 https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/get-started/install/ 200
+      /docs/6.1 https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/get-started/ 200
       /docs/6.1/react/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
       /docs/6.1/vue/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
       /docs/6.1/angular/* https://release-6-1--storybook-frontpage.netlify.app/docs/6.1/:splat 200
@@ -680,7 +680,7 @@ describe('generateRedirects', () => {
       /docs/6.0/solid/workflows/unit-testing/ https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/writing-tests/stories-in-unit-tests/ 301
 
 
-      /docs/6.0 https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/get-started/install/ 200
+      /docs/6.0 https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/get-started/ 200
       /docs/6.0/react/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
       /docs/6.0/vue/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
       /docs/6.0/angular/* https://release-6-0--storybook-frontpage.netlify.app/docs/6.0/:splat 200
@@ -701,13 +701,13 @@ describe('generateRedirects', () => {
       /docs/8.0/writing-docs/introduction https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/writing-docs 301
 
 
-      /docs/8.0 https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/get-started/install/ 200
+      /docs/8.0 https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/get-started/ 200
       /docs/8.0/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
 
 
 
 
-      /docs/next https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/get-started/install/ 200
+      /docs/next https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/get-started/ 200
       /docs/next/react/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
       /docs/next/vue/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200
       /docs/next/angular/* https://release-8-0--storybook-frontpage.netlify.app/docs/8.0/:splat 200

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,26 +1,26 @@
 # See https://www.netlify.com/docs/redirects/
 
 # Older (prev 5.0 doc URLs)
-/basics/quick-start-guide                   /docs/get-started/install/                                                                          301
+/basics/quick-start-guide                   /docs/get-started/                                                                                  301
 /basics/slow-start-guide                    /docs/configure/                                                                                    301
-/basics/guide-react                         /docs/get-started/install/                                                                          301
+/basics/guide-react                         /docs/get-started/                                                                                  301
 /basics/guide-react-native                  https://github.com/storybookjs/react-native#storybook-for-react-native                              301
-/basics/guide-vue                           /docs/get-started/install/                                                                          301
-/basics/guide-angular                       /docs/get-started/install/                                                                          301
-/basics/guide-mithril                       /docs/get-started/install/                                                                          301
-/basics/guide-ember                         /docs/get-started/install/                                                                          301
-/basics/guide-riot                          /docs/get-started/install/                                                                          301
-/basics/guide-html                          /docs/get-started/install/                                                                          301
-/docs/basics/quick-start-guide              /docs/get-started/install/                                                                          301
+/basics/guide-vue                           /docs/get-started/                                                                                  301
+/basics/guide-angular                       /docs/get-started/                                                                                  301
+/basics/guide-mithril                       /docs/get-started/                                                                                  301
+/basics/guide-ember                         /docs/get-started/                                                                                  301
+/basics/guide-riot                          /docs/get-started/                                                                                  301
+/basics/guide-html                          /docs/get-started/                                                                                  301
+/docs/basics/quick-start-guide              /docs/get-started/                                                                                  301
 /docs/basics/slow-start-guide               /docs/configure/                                                                                    301
-/docs/basics/guide-react                    /docs/get-started/install/                                                                          301
+/docs/basics/guide-react                    /docs/get-started/                                                                                  301
 /docs/basics/guide-react-native             https://github.com/storybookjs/react-native#storybook-for-react-native                              301
-/docs/basics/guide-vue                      /docs/get-started/install/                                                                          301
-/docs/basics/guide-angular                  /docs/get-started/install/                                                                          301
-/docs/basics/guide-mithril                  /docs/get-started/install/                                                                          301
-/docs/basics/guide-ember                    /docs/get-started/install/                                                                          301
-/docs/basics/guide-riot                     /docs/get-started/install/                                                                          301
-/docs/basics/guide-html                     /docs/get-started/install/                                                                          301
+/docs/basics/guide-vue                      /docs/get-started/                                                                                  301
+/docs/basics/guide-angular                  /docs/get-started/                                                                                  301
+/docs/basics/guide-mithril                  /docs/get-started/                                                                                  301
+/docs/basics/guide-ember                    /docs/get-started/                                                                                  301
+/docs/basics/guide-riot                     /docs/get-started/                                                                                  301
+/docs/basics/guide-html                     /docs/get-started/                                                                                  301
 
 /basics/*                                   /docs/basics/:splat                                                                                 301
 /configurations/*                           /docs/configurations/:splat                                                                         301
@@ -29,31 +29,31 @@
 /testing/*                                  /docs/testing/:splat                                                                                301
 
 # Pre 6.0 URLs
-/docs/basics/introduction/                  /docs/get-started/install/                                                                          301
+/docs/basics/introduction/                  /docs/get-started/                                                                                  301
 /docs/basics/writing-stories/               /docs/get-started/whats-a-story/                                                                    301
 /docs/basics/exporting-storybook/           /docs/workflows/publish-storybook/                                                                  301
 /docs/basics/faq/                           /docs/workflows/faq/                                                                                301
 /docs/basics/live-examples/                 https://github.com/storybookjs/storybook/blob/next/examples/README.md                               301
 /docs/examples/                             /docs/get-started/examples/                                                                         301
 
-/docs/guides/quick-start-guide/             /docs/get-started/install/                                                                          301
+/docs/guides/quick-start-guide/             /docs/get-started/                                                                                  301
 /docs/guides/slow-start-guide/              /docs/configure/                                                                                    301
-/docs/guides/guide-html/                    /docs/get-started/install/                                                                          301
-/docs/guides/guide-react/                   /docs/get-started/install/                                                                          301
+/docs/guides/guide-html/                    /docs/get-started/                                                                                  301
+/docs/guides/guide-react/                   /docs/get-started/                                                                                  301
 /docs/guides/guide-react-native/            https://github.com/storybookjs/react-native#storybook-for-react-native                              301
-/docs/guides/guide-vue/                     /docs/get-started/install/                                                                          301
-/docs/guides/guide-angular/                 /docs/get-started/install/                                                                          301
-/docs/guides/guide-mithril/                 /docs/get-started/install/                                                                          301
-/docs/mithril/                              /docs/get-started/install/                                                                          301
-/docs/guides/guide-marko/                   /docs/get-started/install/                                                                          301
-/docs/marko/                                /docs/get-started/install/                                                                          301
-/docs/guides/guide-ember/                   /docs/get-started/install/                                                                          301
-/docs/guides/guide-rax/                     /docs/get-started/install/                                                                          301
-/docs/rax/                                  /docs/get-started/install/                                                                          301
-/docs/guides/guide-riot/                    /docs/get-started/install/                                                                          301
-/docs/riot/                                 /docs/get-started/install/                                                                          301
-/docs/guides/guide-svelte/                  /docs/get-started/install/                                                                          301
-/docs/guides/guide-preact/                  /docs/get-started/install/                                                                          301
+/docs/guides/guide-vue/                     /docs/get-started/                                                                                  301
+/docs/guides/guide-angular/                 /docs/get-started/                                                                                  301
+/docs/guides/guide-mithril/                 /docs/get-started/                                                                                  301
+/docs/mithril/                              /docs/get-started/                                                                                  301
+/docs/guides/guide-marko/                   /docs/get-started/                                                                                  301
+/docs/marko/                                /docs/get-started/                                                                                  301
+/docs/guides/guide-ember/                   /docs/get-started/                                                                                  301
+/docs/guides/guide-rax/                     /docs/get-started/                                                                                  301
+/docs/rax/                                  /docs/get-started/                                                                                  301
+/docs/guides/guide-riot/                    /docs/get-started/                                                                                  301
+/docs/riot/                                 /docs/get-started/                                                                                  301
+/docs/guides/guide-svelte/                  /docs/get-started/                                                                                  301
+/docs/guides/guide-preact/                  /docs/get-started/                                                                                  301
 
 /docs/configurations/overview/              /docs/configure/                                                                                    301
 /docs/configurations/options-parameter/     /docs/configure/features-and-behavior/                                                              301


### PR DESCRIPTION
Per https://github.com/storybookjs/storybook/pull/26401

- Place version data directly in site-metadata
- No longer update install guide title
- Update redirects