### PR TITLE
Update URL to 8.0 migration guide

### DIFF
--- a/src/content/releases/8.0.md
+++ b/src/content/releases/8.0.md
@@ -25,5 +25,5 @@ This is a major release, so there are tons of little fixes and improvements. Bro
 ---
 
 There **are** breaking changes. Please refer to our
-[Migration guide](https://storybook.js.org/8.0/docs/migration-guide) to upgrade from
+[Migration guide](https://storybook.js.org/docs/8.0/migration-guide) to upgrade from
 pre-8.0 of Storybook.


### PR DESCRIPTION
![ScreenRecording2024-03-18at14 43 09-ezgif com-video-to-gif-converter](https://github.com/storybookjs/frontpage/assets/8811904/77015c43-bd9d-4336-be00-60980e40c1d5)

Should fix this.