### PR TITLE
Docs: Fix typo in vuetify.md

### DIFF
--- a/src/content/recipes/vuetify.md
+++ b/src/content/recipes/vuetify.md
@@ -53,7 +53,7 @@ Now create a storybook [decorator](/docs/vue/writing-stories/decorators) to wrap
 Below I created a new file in `.storybook` called `withVuetifyTheme.decorator.js`.
 
 ```js
-// .storybook/withVeutifyTheme.decorator.js
+// .storybook/withVuetifyTheme.decorator.js
 import { h } from 'vue';
 import StoryWrapper from './StoryWrapper.vue';
 
@@ -149,7 +149,7 @@ export default {
 Now pass our global `theme` variable to our `StoryWrapper` component as a prop with our decorator
 
 ```js
-// .storybook/withVeutifyTheme.decorator.js
+// .storybook/withVuetifyTheme.decorator.js
 import { h } from 'vue';
 import StoryWrapper from './StoryWrapper.vue';
 


### PR DESCRIPTION
This is my first OSS contribution, so I apologize if there are any mistakes.
Fixed a typo in the `src/content/recipes/vuetify.md` docs page.